### PR TITLE
Revert earlier change to use with

### DIFF
--- a/src/python/strelka/scanners/scan_vba.py
+++ b/src/python/strelka/scanners/scan_vba.py
@@ -16,49 +16,52 @@ class ScanVba(strelka.Scanner):
         self.event['total'] = {'files': 0, 'extracted': 0}
 
         try:
-            with olevba.VBA_Parser(filename=file.name, data=data) as vba:
-                if vba.detect_vba_macros():
-                    extract_macros = list(vba.extract_macros())
-                    self.event['total']['files'] = len(extract_macros)
-                    for (filename, stream_path, vba_filename, vba_code) in extract_macros:
-                        extract_file = strelka.File(
-                            name=f'{vba_filename}',
-                            source=self.name,
+            vba = olevba.VBA_Parser(filename=file.name, data=data)
+            if vba.detect_vba_macros():
+                extract_macros = list(vba.extract_macros())
+                self.event['total']['files'] = len(extract_macros)
+                for (filename, stream_path, vba_filename, vba_code) in extract_macros:
+                    extract_file = strelka.File(
+                        name=f'{vba_filename}',
+                        source=self.name,
+                    )
+
+                    for c in strelka.chunk_string(vba_code):
+                        self.upload_to_coordinator(
+                            extract_file.pointer,
+                            c,
+                            expire_at,
                         )
 
-                        for c in strelka.chunk_string(vba_code):
-                            self.upload_to_coordinator(
-                                extract_file.pointer,
-                                c,
-                                expire_at,
-                            )
+                    self.files.append(extract_file)
+                    self.event['total']['extracted'] += 1
 
-                        self.files.append(extract_file)
-                        self.event['total']['extracted'] += 1
-
-                    if analyze_macros:
-                        self.event.setdefault('auto_exec', [])
-                        self.event.setdefault('base64', [])
-                        self.event.setdefault('dridex', [])
-                        self.event.setdefault('hex', [])
-                        self.event.setdefault('ioc', [])
-                        self.event.setdefault('suspicious', [])
-                        macros = vba.analyze_macros()
-                        for (macro_type, keyword, description) in macros:
-                            if macro_type == 'AutoExec':
-                                self.event['auto_exec'].append(keyword)
-                            elif macro_type == 'Base64 String':
-                                self.event['base64'].append(keyword)
-                            elif macro_type == 'Dridex String':
-                                self.event['dridex'].append(keyword)
-                            elif macro_type == 'Hex String':
-                                self.event['hex'].append(keyword)
-                            elif macro_type == 'IOC':
-                                self.event['ioc'].append(keyword)
-                            elif macro_type == 'Suspicious':
-                                self.event['suspicious'].append(keyword)
-                            elif macro_type == 'VBA obfuscated Strings':
-                                self.event['vba_obfuscated'].append(keyword)
+                if analyze_macros:
+                    self.event.setdefault('auto_exec', [])
+                    self.event.setdefault('base64', [])
+                    self.event.setdefault('dridex', [])
+                    self.event.setdefault('hex', [])
+                    self.event.setdefault('ioc', [])
+                    self.event.setdefault('suspicious', [])
+                    macros = vba.analyze_macros()
+                    for (macro_type, keyword, description) in macros:
+                        if macro_type == 'AutoExec':
+                            self.event['auto_exec'].append(keyword)
+                        elif macro_type == 'Base64 String':
+                            self.event['base64'].append(keyword)
+                        elif macro_type == 'Dridex String':
+                            self.event['dridex'].append(keyword)
+                        elif macro_type == 'Hex String':
+                            self.event['hex'].append(keyword)
+                        elif macro_type == 'IOC':
+                            self.event['ioc'].append(keyword)
+                        elif macro_type == 'Suspicious':
+                            self.event['suspicious'].append(keyword)
+                        elif macro_type == 'VBA obfuscated Strings':
+                            self.event['vba_obfuscated'].append(keyword)
 
         except olevba.FileOpenError:
             self.flags.append('file_open_error')
+        finally:
+            if vba is not None:
+                vba.close()


### PR DESCRIPTION
It turns out this requires an `__enter__` method which vba parser
doesn't implement (and my IDE doesn't know about...).

I thought I'd tested this but I hadn't. Luckily I did before tagging
latest.

**Describe the change**
Include a summary of the change (with required dependencies), any issues it fixes, and relevant motivation and context.

**Describe testing procedures**
Validated that our CI tests pass against this image (they broke with the earlier change/v0.3.4 release). Also validated separately that the changes to scan_ole are hit so that usage of `with` is Ok.

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
