### PR TITLE
Task Send & Receive Long Polling

### DIFF
--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -46,7 +46,7 @@ type request struct {
 	Time       int64               `json:"time,omitempty"`
 }
 
-var checkForResultsSleepRampUp = []time.Duration{time.Millisecond, 10 * time.Millisecond, 100 * time.Millisecond, 100 * time.Millisecond, 250 * time.Millisecond}
+var checkForResultsSleepRampUp = []time.Duration{10 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond, 100 * time.Millisecond, 250 * time.Millisecond}
 
 func (s *server) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil

--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -157,7 +157,7 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
 		(*tx).Del(stream.Context(), sha)
 	}
 
-	for i := 0; ; i++ {
+	for {
 		res, err := s.coordinator.cli.BLPop(stream.Context(), 5*time.Second, keye).Result()
 		if err != nil {
 			continue

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -73,12 +73,11 @@ class Backend(object):
                 if time.time() >= work_expire:
                     break
 
-            task = self.coordinator.zpopmin('tasks', count=1)
-            if len(task) == 0:
-                time.sleep(0.25)
+            task = self.coordinator.bzpopmin('tasks', timeout=5)
+            if task is None:
                 continue
 
-            (root_id, expire_at) = task[0]
+            (queue_name, root_id, expire_at) = task
             root_id = root_id.decode()
             file = strelka.File(pointer=root_id)
             expire_at = math.ceil(expire_at)


### PR DESCRIPTION
**Describe the change**
We observed the 250ms floor latency, and according to scan times in
the Strelka response it looks like it's common for this to be mostly
wait time. The 250ms floor was when there are many backends, but with fewer
backends it was common to be closer to 500ms because of the 250ms poll time
on the BE.

Using long polling on both sides ensures things are about as fast as they can be, and probably
results in less load on redis in steady state.

**Describe testing procedures**
Using small files that evaluated very fast I found that the latency was reduced from 250-500ms to ~20 ms. Large files didn't behave any differently.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
