### PR TITLE
Prevent fast iterations over err + respect ctx cancellation

### DIFF
--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -158,8 +158,14 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
 	}
 
 	for {
+		if err := stream.Context().Err(); err != nil {
+			return err
+		}
+
 		res, err := s.coordinator.cli.BLPop(stream.Context(), 5*time.Second, keye).Result()
 		if err != nil {
+			// Delay to prevent fast looping over errors
+			time.Sleep(250 * time.Millisecond)
 			continue
 		}
 		// first element will be the name of queue/event, second element is event itself

--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -164,8 +164,10 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
 
 		res, err := s.coordinator.cli.BLPop(stream.Context(), 5*time.Second, keye).Result()
 		if err != nil {
-			// Delay to prevent fast looping over errors
-			time.Sleep(250 * time.Millisecond)
+			if err != redis.Nil {
+				// Delay to prevent fast looping over errors
+				time.Sleep(250 * time.Millisecond)
+			}
 			continue
 		}
 		// first element will be the name of queue/event, second element is event itself


### PR DESCRIPTION
**Describe the change**
With the change to BLPOP an err returned by redis will cause an immediate retry/loop. This isn't the best behavior because any persistent errors will result in an infinite loop. Additionally nothing in this loop respects context cancellation, which presumably allows these occurrences to just build up (I'm not sure if anything will cause them to be killed eventually, but I'm not sure what could).

**Describe testing procedures**
Validated everything still works as expected during normal conditions, and I've validated the looping behavior with context cancellation.

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
