### PR TITLE
Fix python-docx to work with python 3.10

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -20,7 +20,7 @@ M2Crypto==0.38.0
 nested-lookup==0.2.22
 numpy==1.22.1
 olefile==0.46
-oletools==0.56.1
+oletools==0.60.1
 opencv-python==4.6.0.66
 opencv-contrib-python==4.6.0.66
 PyMuPDF==1.19.6
@@ -30,7 +30,7 @@ pyelftools==0.27
 pygments==2.9.0
 pylzma==0.5.0
 pytesseract==0.3.7
-python-docx==0.8.10
+python-docx==0.8.11
 python-magic==0.4.22
 py-tlsh==4.7.2
 pyyaml>=5.4.1

--- a/src/python/strelka/scanners/scan_ocr.py
+++ b/src/python/strelka/scanners/scan_ocr.py
@@ -32,7 +32,7 @@ class ScanOcr(strelka.Scanner):
                 tess_txt_name = f'{tmp_tess.name}.txt'
                 if tess_return == 0:
                     with open(tess_txt_name, 'rb') as tess_txt:
-                        ocr_file = tess_txt.read()
+                        ocr_file = tess_txt.read().rstrip()
 
                         if ocr_file:
                             self.event['raw'] = ocr_file


### PR DESCRIPTION
**Describe the change**
Looks like the new base image pulls in Python 3.10, but the `python-docx` package broke because Python makes breaking changes to its stdlib within a minor version? :shameshame:

I updated oletools to the latest as well, and right stripped output from the OCR file.

**Describe testing procedures**
Ran and tweaked backend tests.

**Sample output**
If this change modifies Strelka's output, then please include a sample of the output here.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
