### PR TITLE
Limit scanner timeouts, improve zip scanner

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -64,7 +64,7 @@ scanners:
       priority: 5
       options:
         max_length: 10
-        scanner_timeout: 150 #In seconds
+        scanner_timeout: 20 #In seconds
         log_pws: True
         password_file: '/strelka/config/passwords.dat'
         brute_force: True
@@ -75,7 +75,7 @@ scanners:
       priority: 5
       options:
         max_length: 10
-        scanner_timeout: 150 #In seconds
+        scanner_timeout: 20 #In seconds
         log_pws: True
         password_file: '/strelka/config/passwords.dat'
         brute_force: True

--- a/src/python/strelka/scanners/scan_zip.py
+++ b/src/python/strelka/scanners/scan_zip.py
@@ -24,9 +24,16 @@ class ScanZip(strelka.Scanner):
                 with zipfile.ZipFile(zip_io) as zip_obj:
                     name_list = zip_obj.namelist()
                     self.event['total']['files'] = len(name_list)
+                    self.event['all_paths'] = name_list
+                    self.event['attempted_files'] = []
 
-                    for i, name in enumerate(name_list):
+                    has_flagged_encrypted = False
+
+                    for name in name_list:
+
                         if not name.endswith('/'):
+                            self.event['attempted_files'].append(name)
+
                             if self.event['total']['extracted'] >= file_limit:
                                 break
 
@@ -35,9 +42,9 @@ class ScanZip(strelka.Scanner):
                                 zinfo = zip_obj.getinfo(name)
 
                                 if zinfo.flag_bits & 0x1:
-                                    if i == 0:
+                                    if not has_flagged_encrypted:
                                         self.flags.append('encrypted')
-
+                                        has_flagged_encrypted = True
                                 else:
                                     extract_data = zip_obj.read(name)
 


### PR DESCRIPTION
**Describe the change**
* Fix bug with encrypted flag (only worked if first file in manifest wasn't a folder)
* Always return all contained paths
* Return files that were attempted


**Describe testing procedures**
Tested in consumer

