### PR TITLE
Scan extracted files with custom yara

### DIFF
--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -90,8 +90,7 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
 		p := s.coordinator.cli.Pipeline()
 		p.RPush(stream.Context(), keyd, in.Data)
 		p.ExpireAt(stream.Context(), keyd, deadline)
-		p.RPush(stream.Context(), keyy, in.YaraData)
-		p.ExpireAt(stream.Context(), keyy, deadline)
+		p.SetNX(stream.Context(), keyy, in.YaraData, time.Until(deadline))
 		if _, err := p.Exec(stream.Context()); err != nil {
 			return err
 		}

--- a/src/go/cmd/strelka-frontend/main.go
+++ b/src/go/cmd/strelka-frontend/main.go
@@ -90,7 +90,14 @@ func (s *server) ScanFile(stream strelka.Frontend_ScanFileServer) error {
 		p := s.coordinator.cli.Pipeline()
 		p.RPush(stream.Context(), keyd, in.Data)
 		p.ExpireAt(stream.Context(), keyd, deadline)
+
+		// We're using a different pattern for YARA data, because (unlike the file data) it's not chunked.
+		// Additionally, we want to ensure the key stays populated for all exploded sub-documents so that
+		// the YARA can be evaluated against them too. Using the 'rpush/rpop' pattern would be cumbersome
+		// because we'd have to pass the yara data through the scanners and back into the queue for every
+		// sub-document.
 		p.SetNX(stream.Context(), keyy, in.YaraData, time.Until(deadline))
+
 		if _, err := p.Exec(stream.Context()); err != nil {
 			return err
 		}

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -136,6 +136,10 @@ class Backend(object):
                             break
                         data += pop
 
+                        # We use the root_id to locate custom yara for this document,
+                        # since both the parent document and all child documents will
+                        # take this path, and we wish to evaluate each against the
+                        # same set of yara rules.
                         yaraData = self.coordinator.get(f'yara:{root_id}')
 
                     file.add_flavors({'mime': self.taste_mime(data)})

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -32,7 +32,6 @@ class Backend(object):
         self.backend_cfg = backend_cfg
         self.coordinator = coordinator
         self.limits = backend_cfg.get('limits')
-        self.yaraData = ''
 
         scanners = backend_cfg.get('scanners')
         if isinstance(scanners, str):
@@ -112,15 +111,9 @@ class Backend(object):
 
     def taste_yara(self, data):
         """Tastes file data with YARA."""
-        # TODO: cache compiled yara and make this more efficient in general
-        compiled_custom_yara = b''
-        if self.yaraData:
-            compiled_custom_yara = yara.compile(source=self.yaraData)
         encoded_whitespace = string.whitespace.encode()
         stripped_data = data.lstrip(encoded_whitespace)
         yara_matches = self.compiled_yara.match(data=stripped_data)
-        if compiled_custom_yara:
-            yara_matches.extend(compiled_custom_yara.match(data=stripped_data))
         return [match.rule for match in yara_matches]
 
     def distribute(self, root_id, file, expire_at):
@@ -143,11 +136,7 @@ class Backend(object):
                             break
                         data += pop
 
-                        ypop = self.coordinator.lpop(f'yara:{file.pointer}')
-                        if ypop is not None:
-                            yaraData += ypop
-
-                    self.yaraData = yaraData.decode()
+                        yaraData = self.coordinator.get(f'yara:{root_id}')
 
                     file.add_flavors({'mime': self.taste_mime(data)})
                     file.add_flavors({'yara': self.taste_yara(data)})
@@ -202,7 +191,7 @@ class Backend(object):
                             options = scanner.get('options', {})
 
                             if name == 'ScanYara':
-                                options['source'] = self.yaraData
+                                options['source'] = yaraData.decode()
 
                             und_name = inflection.underscore(name)
                             scanner_import = f'strelka.scanners.{und_name}'

--- a/src/python/strelka/scanners/scan_yara.py
+++ b/src/python/strelka/scanners/scan_yara.py
@@ -34,6 +34,7 @@ class ScanYara(strelka.Scanner):
 
         compiled_custom_yara = None
         if options.get('source'):
+            # custom yara was provided - use it to evaluate this file
             try:
                 compiled_custom_yara = yara.compile(source=options['source'])
             except (yara.Error, yara.SyntaxError):


### PR DESCRIPTION
**Describe the change**
Extracted files were not being scanned because `file.pointer` was used as a key instead of `root_id`. This PR fixes that.

**Describe testing procedures**
Run `strelka-oneshot` on a PDF that has embedded documents, e.g. ` go run github.com/target/strelka/src/go/cmd/strelka-oneshot -f ~/Downloads/ticket.pdf -y custom-rules.yara`

**Sample output**
Output from after change (before change, `MatchAllCustom2` would not have matched all children):

```
...
{"file":{"depth":1,"flavors":{"mime":["font/sfnt"]},"name":"object_31","scanners":["ScanEntropy","ScanFooter","ScanHash","ScanHeader","ScanYara"],"size":52968,"source":"ScanPdf","tree":{"node":"7c1df931-3ca5-4b96-84c3-3111917cbba7","parent":"2f07f2c3-03bd-44a6-bf3e-319c3f7f1596","root":"2f07f2c3-03bd-44a6-bf3e-319c3f7f1596"}},"request":{"attributes":{"filename":"/Users/madi/Downloads/ticket.pdf","yaraFilename":"custom-rules.yara"},"client":"go-oneshot","id":"2f07f2c3-03bd-44a6-bf3e-319c3f7f1596","source":"Madisons-MBP-2.lan","time":1673029426},"scan":{"entropy":{"elapsed":0.000098,"entropy":5.35301088908125},"footer":{"elapsed":0.00001,"footer":"u++sss+++s+sstu++stu++stu++++++++++++tu\u0000+++EiD+\u0000\u0000\u0000"},"hash":{"elapsed":0.000566,"md5":"b5cf89d90e9ad6e56bcec92fc361ad9d","sha1":"362134cd35494cd7fdf63ad7d54482b66270962e","sha256":"4584b969c02e8808cfbb65fe0d8bbd2d65e01484e05388773e594c487740dd5b","ssdeep":"384:0+rn5vZUV+/Yuxp3XRQubeEDZ72KdJbvWAiChYacxCZbYNCsJAr8li8aa/8kh33F:hqV0dXhbB2KdJx2COliSOzyaPPZM"},"header":{"elapsed":0.000045,"header":"\u0000\u0001\u0000\u0000\u0000\t\u0000�\u0000\u0003\u0000\u0010cvt �íG\u0000\u0000\u0000�\u0000\u0000\u0007`fpgm�'\u0011�\u0000\u0000\u0007�\u0000\u0000\u0006\u003eglyfè"},"yara":{"elapsed":0.001992,"matches":[{"name":"test"},{"meta":{"author":"madi","description":"my test rule"},"name":"MatchAllCustom2"}]}}}

{"file":{"depth":1,"flavors":{"mime":["text/plain"]},"name":"object_34","scanners":["ScanEntropy","ScanFooter","ScanHash","ScanHeader","ScanUrl","ScanYara"],"size":858,"source":"ScanPdf","tree":{"node":"4385b7b2-83a0-4506-aeae-765b0e845c85","parent":"2f07f2c3-03bd-44a6-bf3e-319c3f7f1596","root":"2f07f2c3-03bd-44a6-bf3e-319c3f7f1596"}},"request":{"attributes":{"filename":"/Users/madi/Downloads/ticket.pdf","yaraFilename":"custom-rules.yara"},"client":"go-oneshot","id":"2f07f2c3-03bd-44a6-bf3e-319c3f7f1596","source":"Madisons-MBP-2.lan","time":1673029426},"scan":{"entropy":{"elapsed":0.000037,"entropy":4.488783523657993},"footer":{"elapsed":0.000011,"footer":"Name currentdict /CMap defineresource pop\nend end\n"},"hash":{"elapsed":0.000049,"md5":"fd306f6d6d9714346caf1f0f95f0ac7d","sha1":"305f36e2ecf0bf6fb40acf936538882ea3b1afaf","sha256":"e8f4f91ec04d39790269c9fcf98c5ba53c211daed52085dbd4867bde94cf8799","ssdeep":"24:VGtV5wpUE9UCaeX8E0YcN+rPLFjM2/sb4h3EUA:VGt/wpUSUI8bYIQTsUFA"},"header":{"elapsed":0.000008,"header":"/CIDInit /ProcSet findresource begin\n12 dict begin"},"url":{"elapsed":0.00008},"yara":{"elapsed":0.001703,"matches":[{"name":"test"},{"meta":{"author":"madi","description":"my test rule"},"name":"MatchAllCustom2"}]}}}
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
