### PR TITLE
Remove default signature

### DIFF
--- a/configs/python/backend/rules.yara
+++ b/configs/python/backend/rules.yara
@@ -1,6 +1,0 @@
-rule test
-// This rule verifies the scanYara scanner works. Add rules here for quickstart scanning.
-{
-  condition:
-    true
-}


### PR DESCRIPTION
**Describe the change**
In local dev, this matches every message and can be very confusing. There's no reason to keep it.

**Describe testing procedures**
Ingest messages with a rule active which looks for `len(.scan.yara.matches) > 0` and no other rules ... the message should not flag.

**Sample output**
N/A

**Checklist**
N/A
