### PR TITLE
Adding Onenote rule & scanner

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -453,6 +453,7 @@ scanners:
           - 'hta_file'
           - 'text/rtf'
           - 'rtf_file'
+          - 'onenote_file'
       priority: 5
 #  'ScanSwf':
 #    - positive:

--- a/build/configs/taste.yara
+++ b/build/configs/taste.yara
@@ -232,6 +232,17 @@ rule ooxml_file {
         uint32(0) == 0x04034B50 and uint32(4) == 0x00060014
 }
 
+rule onenote_file {
+    meta:
+        author = "Aiden Mitchell"
+        description = "Microsoft Onenote File"
+        type = "document"
+    strings:
+        $a = { E4 52 5C 7B 8C D8 A7 4D AE B1 53 78 D0 29 96 D3 }
+    condition:
+        $a at 0
+}
+
 rule pdf_file {
     meta:
         description = "Portable Document Format"

--- a/build/configs/taste.yara
+++ b/build/configs/taste.yara
@@ -230,7 +230,7 @@ rule onenote_file {
         description = "Microsoft Onenote File"
         type = "document"
     strings:
-        $a = { E4 52 5C 7B 8C D8 A7 4D AE B1 53 78 D0 29 96 D3 }
+        $a = { E4 52 5C 7B 8C D8 A7 4D AE B1 53 78 D0 29 96 D3 } // .one guidFileType
     condition:
         $a at 0
 }

--- a/build/configs/taste.yara
+++ b/build/configs/taste.yara
@@ -224,14 +224,6 @@ rule olecf_file {
         uint32(0) == 0xE011CFD0 and uint32(4) == 0xE11AB1A1
 }
 
-rule ooxml_file {
-    meta:
-        description = "Microsoft Office Open XML Format"
-        type  = "document"
-    condition:
-        uint32(0) == 0x04034B50 and uint32(4) == 0x00060014
-}
-
 rule onenote_file {
     meta:
         author = "Aiden Mitchell"
@@ -241,6 +233,14 @@ rule onenote_file {
         $a = { E4 52 5C 7B 8C D8 A7 4D AE B1 53 78 D0 29 96 D3 }
     condition:
         $a at 0
+}
+
+rule ooxml_file {
+    meta:
+        description = "Microsoft Office Open XML Format"
+        type  = "document"
+    condition:
+        uint32(0) == 0x04034B50 and uint32(4) == 0x00060014
 }
 
 rule pdf_file {


### PR DESCRIPTION
**Describe the change**
Added a YARA flavour to detect Microsoft Onenote (`.one`) files, and added the flavour to the ScanStrings scanner.

**Describe testing procedures**
Added flavour and scanner rule in my environment, and ran an email with an attached `.one` file. `binexplode` returned expected results.

**Sample output**
```json
"result": [
                [
                    {
                        "depth": 0,
                        "flavors": {
                            "mime": "application/octet-stream",
                            "yara": [
                                "onenote_file"
                            ]
                        },
                        "size": 13504,
                        "name": "onenote_one_embedded_hta_rtlo.one",
                        "extension": "one",
                        "node_id": "bfce71aa-3f9f-4a0f-8785-6e7f4bb7b59f",
                        "scan": {
                            "entropy": {
                                "entropy": 3.2809219605231594
                            },
                            "hash": {
                                "md5": "028bf224490a965c0e70ab5f81269941",
                                "sha1": "016fbe544de546bb53ef1f25b75f0f65d70208a1",
                                "sha256": "62ab2d3c134499f00452d89ee47d868f3a9620c60c7dccad22a919dae704ae62",
                                "ssdeep": "96:Nbz3Lf/04SsRCuWH1zUmi0wD5KaZfFb1cDRpAyTHeUfMYTHzu1:xnOHJjt2KaZf/cDRpbTH1ftHzu1"
                            },
                            "strings": {
                                "strings": [
                                    "A&oB",
                                    "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">",
                                    "<html xmlns=\"http://www.w3.org/1999/xhtml\">",
                                    "  <head>",
                                    "    <meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\" />",
                                    "    <title>delivr.to</title>",
                                    "    <script language=\"VBScript\">",
                                    "      set oShell = CreateObject(\"Wscript.Shell\")",
                                    "      oShell.Run(\"calc.exe\"),0,true",
                                    "      self.close()",
                                    "    </script>",
                                    "    <hta:application",
                                    "      id=\"oHTA\"",
                                    "      applicationname=\"delivr.to\"",
                                    "      application=\"yes\"",
                                    "    >",
                                    "    </hta:application>",
                                    "  </head>",
                                    "  <body>",
                                    "  </body>",
                                    "</html>",
                                    "VBk$",
                                    "A delivr.to embedded hta file test",
                                    "7:56 PM",
                                    "Friday, January 13, 2023",
                                    "jh~B",
                                    "delivr.to OneNote",
                                    "IHDR",
                                    "sRGB",
                                    "pHYs",
                                    "IDATXG",
                                    "m's7",
                                    "IEND",
                                    "VBk$",
                                    "A&oB"
                                ]
                            }
                        }
                    }
                ]
            ]
```

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
