### PR TITLE
Revert "Add PDF flavor to ScanStrings"

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -460,7 +460,6 @@ scanners:
           - 'hta_file'
           - 'text/rtf'
           - 'rtf_file'
-          - 'pdf_file'
           - 'onenote_file'
           - 'application/onenote'
           - 'application/msonenote'


### PR DESCRIPTION
Reverts sublime-security/strelka#43

Appeared to cause timeouts because the strings inside PDF are often a bunch of short ASCII garbage strings. We can enable this again in the future, and prune out random ASCII sequences from that list. TBD.