### PR TITLE
Follow up to #55 (we have two scanner configs)

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -93,6 +93,8 @@ scanners:
           - 'vbframe_file'
           - 'mso_file'
           - 'application/vnd.ms-excel'
+          - 'application/zip'
+          - 'zip_file'
       priority: 5
       options:
         keys:


### PR DESCRIPTION
**Describe the change**
`configs/python/backend/backend.yaml` isn't what's used in our fork. `build/configs/scanners.yaml` is what we actually respect (it's built into our images).