### PR TITLE
Use precompiled wheel for ARM64 lief

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -112,8 +112,7 @@ RUN mkdir jtr && cd jtr && git init && git remote add origin https://github.com/
 
 # Install Python packages
 COPY ./build/python/backend/requirements.txt /strelka/requirements.txt
-RUN pip3 install --no-cache-dir -r /strelka/requirements.txt && \
-    pip3 install --index-url https://lief-project.github.io/packages --trusted-host lief.quarkslab.com lief
+RUN pip3 install --no-cache-dir -r /strelka/requirements.txt
 
 # Copy Strelka files
 COPY ./src/python/ /strelka/

--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -1,3 +1,4 @@
+# --index-url https://lief-project.github.io/packages --trusted-host lief.quarkslab.com
 arc4==0.0.4
 beautifulsoup4==4.9.3
 boltons==20.2.1
@@ -14,7 +15,12 @@ inflection==0.5.1
 interruptingcow==0.8
 jsbeautifier==1.13.13
 libarchive-c==2.9
-lief==0.12.1
+
+
+# lief doesn't have prebuilt binaries for ARM64 in PyPi, use our own prebuilt binary
+https://sublime-python-deps.s3.amazonaws.com/lief-0.12.3-cp310-cp310-linux_aarch64.whl; sys_platform == 'linux' and (platform_machine == 'arm64' or platform_machine == 'aarch64')
+lief==0.12.3; sys_platform != 'linux' or (platform_machine != 'arm64' and platform_machine != 'aarch64')
+
 lxml==4.9.1
 M2Crypto==0.38.0
 nested-lookup==0.2.22


### PR DESCRIPTION
**Describe the change**
Build times were crazy slow for ARM64 because there wasn't a precompiled wheel for `lief` in PyPi for Python3.10 + ARM64! For this specific combination, I ran `python3 -m pip3 wheel lief==0.12.3` and the compiled `.whl` file is uploaded somewhere these builds can reach.


**Describe testing procedures**
Built successfully with Apple Silicon locally, and confirmed the architecture is still linux/arm64.
