### PR TITLE
Convert timeout to integer using math.ceiling

### DIFF
--- a/src/python/strelka/scanners/scan_yara.py
+++ b/src/python/strelka/scanners/scan_yara.py
@@ -1,6 +1,7 @@
 import copy
 import glob
 import hashlib
+import math
 import os
 import time
 
@@ -78,12 +79,13 @@ class ScanYara(strelka.Scanner):
         try:
             yara_matches = []
 
-            timeout = expire_at - time.time()
+            timeout = math.ceil(expire_at - time.time())
+
             if self.compiled_yara is not None:
                 yara_matches = self.compiled_yara.match(data=data, timeout=timeout)
 
             for custom_yara in compiled_custom_yara:
-                timeout = expire_at - time.time()
+                timeout = math.ceil(expire_at - time.time())
                 yara_matches.extend(custom_yara.match(data=data, timeout=timeout))
 
             for match in yara_matches:


### PR DESCRIPTION
`yara-python` interestingly requires an integer here.

Fixes:
![image](https://user-images.githubusercontent.com/611653/235033092-3d7214e8-22c1-4f87-9825-3210dc097bb2.png)
