### PR TITLE
Drop ScanQR from config

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -394,18 +394,18 @@ scanners:
 #          - 'ProgramArguments'
 #          - 'RunAtLoad'
 #          - 'StartInterval'
-  'ScanQr':
-    - positive:
-        flavors:
-          - 'image/jpeg'
-          - 'jpeg_file'
-          - 'image/png'
-          - 'png_file'
-          - 'image/tiff'
-          - 'type_is_tiff'
-          - 'image/x-ms-bmp'
-          - 'bmp_file'
-      priority: 5
+#   'ScanQr':
+#     - positive:
+#         flavors:
+#           - 'image/jpeg'
+#           - 'jpeg_file'
+#           - 'image/png'
+#           - 'png_file'
+#           - 'image/tiff'
+#           - 'type_is_tiff'
+#           - 'image/x-ms-bmp'
+#           - 'bmp_file'
+#       priority: 5
   'ScanRar':
     - positive:
         flavors:


### PR DESCRIPTION
Drop `ScanQR` from scanners config, because it adds unnecessary time and isn't used for any rules. We can always bring it back, and revisit how to be more selective then.

<!-- Notion: https://www.notion.so/sublimesecurity/3e27cf7ed88b4d8a938e57b4492a8d10?pvs=4 -->