### PR TITLE
Drop ScanQr from backend.yaml also

### DIFF
--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -402,18 +402,18 @@ scanners:
           - 'ProgramArguments'
           - 'RunAtLoad'
           - 'StartInterval'
-  'ScanQr':
-    - positive:
-        flavors:
-          - 'image/jpeg'
-          - 'jpeg_file'
-          - 'image/png'
-          - 'png_file'
-          - 'image/tiff'
-          - 'type_is_tiff'
-          - 'image/x-ms-bmp'
-          - 'bmp_file'
-      priority: 5
+#  'ScanQr':
+#    - positive:
+#        flavors:
+#          - 'image/jpeg'
+#          - 'jpeg_file'
+#          - 'image/png'
+#          - 'png_file'
+#          - 'image/tiff'
+#          - 'type_is_tiff'
+#          - 'image/x-ms-bmp'
+#          - 'bmp_file'
+#      priority: 5
   'ScanRar':
     - positive:
         flavors:


### PR DESCRIPTION
Apparently #67 wasn't enough and it needed to be dropped from `backend.yaml`. Confirmed locally that this one actually disables  ScanQR.