### PR TITLE
Convert PDF to PNG before running OCR

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -320,10 +320,13 @@ scanners:
           - 'type_is_tiff'
           - 'image/x-ms-bmp'
           - 'bmp_file'
+          - 'application/pdf'
+          - 'pdf'
       priority: 5
       options:
         extract_text: True
         tmp_directory: '/dev/shm/'
+        pdf_to_png: True
   'ScanOle':
     - positive:
         flavors:

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -327,10 +327,13 @@ scanners:
           - 'type_is_tiff'
           - 'image/x-ms-bmp'
           - 'bmp_file'
+          - 'application/pdf'
+          - 'pdf_file'
       priority: 5
       options:
         extract_text: False
         tmp_directory: '/dev/shm/'
+        pdf_to_png: True
   'ScanOle':
     - positive:
         flavors:

--- a/src/python/strelka/scanners/scan_ocr.py
+++ b/src/python/strelka/scanners/scan_ocr.py
@@ -1,3 +1,4 @@
+import fitz
 import os
 import subprocess
 import tempfile
@@ -18,6 +19,11 @@ class ScanOcr(strelka.Scanner):
     def scan(self, data, file, options, expire_at):
         extract_text = options.get('extract_text', False)
         tmp_directory = options.get('tmp_directory', '/tmp/')
+        pdf_to_png = options.get('pdf_to_png', False)
+
+        if pdf_to_png and 'application/pdf' in file.flavors.get('mime', []):
+            doc = fitz.open(stream=data, filetype='pdf')
+            data = doc.get_page_pixmap(0).tobytes('png')
 
         with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
             tmp_data.write(data)


### PR DESCRIPTION
Adds the ability to convert PDF documents into PNG images of their first page. This is controlled by the `pdf_to_png` option.

<img width="761" alt="image" src="https://github.com/sublime-security/strelka/assets/3705729/bcd693f8-423a-4dcc-9ddc-add208cc4954">
