### PR TITLE
Switch to ubuntu:22.04

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 


### PR DESCRIPTION
**Describe the change**
Use `ubuntu22.04` since it's LTS and the dockerhub image [is still maintained](https://hub.docker.com/_/ubuntu/tags?page=1&name=22). We can't build 22.10 anymore because some ubuntu repositories are broken. We could in theory fix those, but I'd rather figure out 23.04.

I would love to update to 23.04, but that goes from Python 3.10 -> Python 3.11 and they keep making breaking ecosystem changes. This unblocks us and we can figure that out later.

Mostly supersedes #76, assuming we don't care to solve new Python 3.11 issues.
