### PR TITLE
Adding webp to strelka scanners

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -166,6 +166,7 @@ scanners:
           - 'bmp_file'
           - 'application/x-shockwave-flash'
           - 'fws_file'
+          - 'image/webp'
       priority: 5
       options:
         keys:
@@ -322,6 +323,7 @@ scanners:
           - 'bmp_file'
           - 'application/pdf'
           - 'pdf'
+          - 'image/webp'
       priority: 5
       options:
         extract_text: True
@@ -408,6 +410,7 @@ scanners:
           - 'type_is_tiff'
           - 'image/x-ms-bmp'
           - 'bmp_file'
+          - 'image/webp'
       priority: 5
   'ScanRar':
     - positive:

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -168,6 +168,7 @@ scanners:
           - 'bmp_file'
           - 'application/x-shockwave-flash'
           - 'fws_file'
+          - 'image/webp'
       priority: 5
       options:
         keys:
@@ -329,6 +330,7 @@ scanners:
           - 'bmp_file'
           - 'application/pdf'
           - 'pdf_file'
+          - 'image/webp'
       priority: 5
       options:
         extract_text: False
@@ -416,6 +418,7 @@ scanners:
           - 'type_is_tiff'
           - 'image/x-ms-bmp'
           - 'bmp_file'
+          - 'image/webp'
       priority: 5
   'ScanRar':
     - positive:

--- a/configs/python/backend/backend.yaml
+++ b/configs/python/backend/backend.yaml
@@ -168,7 +168,6 @@ scanners:
           - 'bmp_file'
           - 'application/x-shockwave-flash'
           - 'fws_file'
-          - 'image/webp'
       priority: 5
       options:
         keys:
@@ -330,7 +329,6 @@ scanners:
           - 'bmp_file'
           - 'application/pdf'
           - 'pdf_file'
-          - 'image/webp'
       priority: 5
       options:
         extract_text: False
@@ -418,7 +416,6 @@ scanners:
           - 'type_is_tiff'
           - 'image/x-ms-bmp'
           - 'bmp_file'
-          - 'image/webp'
       priority: 5
   'ScanRar':
     - positive:


### PR DESCRIPTION
**Describe the change**
Added `image/webp` to usual image scanners to account for a detection gap.

**Describe testing procedures**
Ran a local instance with webp scanning enabled and it returned expected results.
