### PR TITLE
Drop .scan.ocr.text output

### DIFF
--- a/src/python/strelka/scanners/scan_ocr.py
+++ b/src/python/strelka/scanners/scan_ocr.py
@@ -42,7 +42,6 @@ class ScanOcr(strelka.Scanner):
 
                         if ocr_file:
                             self.event['raw'] = ocr_file
-                            self.event['text'] = ocr_file.split()
 
                             if extract_text:
                                 extract_file = strelka.File(


### PR DESCRIPTION
This was deprecated a long time ago and is safe to remove now. Removes JSON bloat and is completely redundant with `.scan.ocr.raw`, but worse.