### PR TITLE
Update PyMuPDF to 1.23.5 and use explicit DPI for PDF->PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Guidelines for contributing can be found [here](https://github.com/target/strelk
 
 ## Known Issues
 There is currently a known issue with compilation on ARM based hosts (e.g., Apple M1). Attempting to compile the current version of Strelka will lead to the following issue:
-https://github.com/target/strelka/issues/188. You can bypass this compilation issue by removing `pymupdf` from the backend Python `requriements.txt` file and commenting out ScanPDF in the `backend.yml` file. Doing this will allow you to compile the current version of Strelka at the expense of being unable to scan PDF files.
+https://github.com/target/strelka/issues/188. You can bypass this compilation issue by removing `pymupdf` from the backend Python `requirements.txt` file and commenting out ScanPDF in the `backend.yml` file. Doing this will allow you to compile the current version of Strelka at the expense of being unable to scan PDF files.
 
 ## Related Projects
 * [Laika BOSS](https://github.com/lmco/laikaboss)

--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -29,7 +29,7 @@ olefile==0.46
 oletools==0.60.1
 opencv-python==4.6.0.66
 opencv-contrib-python==4.6.0.66
-PyMuPDF==1.19.6
+PyMuPDF==1.23.5
 pefile==2019.4.18
 pgpdump3==1.5.2
 pyelftools==0.27

--- a/src/python/strelka/scanners/scan_ocr.py
+++ b/src/python/strelka/scanners/scan_ocr.py
@@ -22,8 +22,9 @@ class ScanOcr(strelka.Scanner):
         pdf_to_png = options.get('pdf_to_png', False)
 
         if pdf_to_png and 'application/pdf' in file.flavors.get('mime', []):
+            # TODO: Use fitz builtin OCR support which also wraps tesseract
             doc = fitz.open(stream=data, filetype='pdf')
-            data = doc.get_page_pixmap(0).tobytes('png')
+            data = doc.get_page_pixmap(0, dpi=150).tobytes('png')
 
         with tempfile.NamedTemporaryFile(dir=tmp_directory) as tmp_data:
             tmp_data.write(data)


### PR DESCRIPTION
Fairly self-explanatory.

- Updated the `PyMuPDF` dependency to the latest version
- Handled some breaking API changes
- Added explicit DPI when converting PDFs to PNGs before OCR scanning
- Added traceback logging for exceptions in `scan_pdf`. Before, these were completely swallowed.

<!-- https://www.notion.so/sublimesecurity/2fde10313e124f1ea732a7339379101f?pvs=4 -->