### PR TITLE
Cleanup trailing whitespace in OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ More documentation about Strelka can be found in the [README](https://target.git
 ## Contribute
 Guidelines for contributing can be found [here](https://github.com/target/strelka/blob/master/CONTRIBUTING.md).
 
-## Known Issues
-There is currently a known issue with compilation on ARM based hosts (e.g., Apple M1). Attempting to compile the current version of Strelka will lead to the following issue:
-https://github.com/target/strelka/issues/188. You can bypass this compilation issue by removing `pymupdf` from the backend Python `requirements.txt` file and commenting out ScanPDF in the `backend.yml` file. Doing this will allow you to compile the current version of Strelka at the expense of being unable to scan PDF files.
-
 ## Related Projects
 * [Laika BOSS](https://github.com/lmco/laikaboss)
 * [File Scanning Framework](https://github.com/EmersonElectricCo/fsf)

--- a/src/python/strelka/scanners/scan_ocr.py
+++ b/src/python/strelka/scanners/scan_ocr.py
@@ -41,6 +41,9 @@ class ScanOcr(strelka.Scanner):
                     with open(tess_txt_name, 'rb') as tess_txt:
                         ocr_file = tess_txt.read().rstrip()
 
+                        # Convert line endings and strip trailing whitespace per line
+                        ocr_file = b'\n'.join([line.rstrip() for line in ocr_file.splitlines()])
+
                         if ocr_file:
                             self.event['raw'] = ocr_file
 


### PR DESCRIPTION
It really doesn't make sense to have trailing whitespace for a line in OCR, so we're dropping it.