### PR TITLE
Drop unused dependency

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -47,7 +47,6 @@ redis==3.5.3
 requests==2.25.1
 rpmfile==1.0.8
 signify==0.3.0
-speakeasy-emulator==1.5.2
 ssdeep==3.4
 tldextract==3.1.0
 tnefparse==1.4.0


### PR DESCRIPTION
Drop this dependency which is not needed. It was added in the upstream accidentally and also removed since it was unused.

- https://github.com/target/strelka/pull/168/files
- https://github.com/target/strelka/commit/b14526ae4d56c187e3a6f15f3513b418d0942f2e

<!-- https://www.notion.so/sublimesecurity/Remove-speakeasy-Package-from-Strelka-Setup-dbd5fa1a52ed47d58fcbee48b250d3dd?pvs=4 -->