### PR TITLE
Removing javascript_file negative from ScanUrl

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -506,10 +506,7 @@ scanners:
       options:
         tmp_directory: '/dev/shm/'
   'ScanUrl':
-    - negative:
-        flavors:
-          - 'javascript_file'
-      positive:
+    - positive:
         flavors:
           - 'text/plain'
           - 'text/html'


### PR DESCRIPTION
TL;DR: some attached HTML files come back with both `javascript_file` and `html_file` which stops us from pulling out URLs. This should fix that.
