### PR TITLE
Update scan_html.py

### DIFF
--- a/src/python/strelka/scanners/scan_html.py
+++ b/src/python/strelka/scanners/scan_html.py
@@ -15,6 +15,9 @@ class ScanHtml(strelka.Scanner):
     def scan(self, data, file, options, expire_at):
         parser = options.get('parser', 'html.parser')
 
+        # Store raw HTML data
+        self.event['raw'] = data.decode('utf-8', errors='replace')
+
         self.event['total'] = {
             'scripts': 0,
             'forms': 0,


### PR DESCRIPTION
Preserve the raw HTML as .scan.html.raw

**Describe the change**
Preserve the raw HTML as .scan.html.raw. Without preserving raw to inspect the contents of the entire html file we're reliant on strings, this however creates an array, which cannot be used to inspect holistically with regex. 


**Describe testing procedures**
Adding raw, should produce a .scan.html.raw..Although we may want to put a boundary around lines or size in some capacity. 
Not saying this is ready to go, but I'd like eng to check it out. 




