### PR TITLE
Use public runner group runners

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -13,9 +13,9 @@ jobs:
         arch: [arm64, amd64]
         include:
           - arch: arm64
-            runner: arm-8vcpu-ubuntu-22
+            runner: arm-8vcpu-ubuntu-22-public
           - arch: amd64
-            runner: ubuntu-latest-4-cores
+            runner: ubuntu-latest-4-cores-public
 
     runs-on: ${{ matrix.runner }}
     environment: production


### PR DESCRIPTION
**Describe the change**
https://github.com/sublime-security/strelka/actions/runs/11134337602

The release workflow isn't picking up a runner. I had to dig a little but it turns out our customized runners are part of our default group, which isn't accessible to public repos. GH cautions about sharing public/private runners, although I think it's really more about self hosted runners which might have additional permissions/networking/etc. I didn't see any drawback so I just created a new runner group which can be allowed for public repos and created identical runners within the group. This change just references those new runners.

**Describe testing procedures**
None, I could test in PR but keeping it simple since I'm pretty sure this is all that's required. If this still doesn't work I'll play around more, but there's no impact besides potentially needing to make another change.

