### PR TITLE
Remediates Python Vulns

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -3,13 +3,13 @@ arc4==0.0.4
 beautifulsoup4==4.9.3
 boltons==20.2.1
 construct==2.10.67
-cryptography==3.4.7
+cryptography==43.0.0
 docker==5.0.0
 esprima==4.0.1
 eml-parser>=1.17
 git+https://github.com/jshlbrd/python-entropy.git   # v0.11 as of this freeze (package installed as 'entropy')
-grpcio==1.42.0
-grpcio-tools==1.42.0
+grpcio==1.67.1
+grpcio-tools==1.67.1
 html5lib==1.1
 inflection==0.5.1
 interruptingcow==0.8
@@ -48,6 +48,6 @@ requests==2.25.1
 rpmfile==1.0.8
 signify==0.3.0
 ssdeep==3.4
-tldextract==3.1.0
+tldextract==5.1.3
 tnefparse==1.4.0
 xmltodict==0.12.0


### PR DESCRIPTION
**Describe the change**
Remediates python vulns:

```
{
    "file" : "/usr/local/lib/python3.10/dist-packages/idna",
    "name" : "CVE-2024-3651",
    "description" : "A vulnerability was identified in the kjd/idna library, specifically within the `idna.encode()` function, affecting version 3.6. The issue arises from the function's handling of crafted input strings, which can lead to quadratic complexity and consequently, a denial of service condition. This vulnerability is triggered by a crafted input that causes the `idna.encode()` function to process the input with considerable computational load, significantly increasing the processing time in a quadratic manner relative to the input size.",
    "severity" : "high",
    "score_version" : "CVSS v3",
  }
```

Installed `pipdeptree` and found that `idna` comes from `tldextract` indrectly. Upgraded to latest.

```
tldextract==5.1.3
├── filelock [required: >=3.0.8, installed: 3.16.1]
├── idna [required: Any, installed: 2.10]
├── requests [required: >=2.1.0, installed: 2.25.1]
│   ├── certifi [required: >=2017.4.17, installed: 2024.8.30]
│   ├── chardet [required: >=3.0.2,<5, installed: 4.0.0]
│   ├── idna [required: >=2.5,<3, installed: 2.10]
│   └── urllib3 [required: >=1.21.1,<1.27, installed: 1.26.20]
└── requests-file [required: >=1.4, installed: 2.1.0]
    └── requests [required: >=1.0.0, installed: 2.25.1]
        ├── certifi [required: >=2017.4.17, installed: 2024.8.30]
        ├── chardet [required: >=3.0.2,<5, installed: 4.0.0]
        ├── idna [required: >=2.5,<3, installed: 2.10]
        └── urllib3 [required: >=1.21.1,<1.27, installed: 1.26.20]
```


There were several vulns directly related to `grpcio` and `cryptography` that I addressed by bumping to latest.
