### PR TITLE
Adding 'image/svg+xml'

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -478,6 +478,7 @@ scanners:
           - 'text/rtf'
           - 'xml_file'
           - 'svg_file'
+          - 'image/svg+xml'
       priority: 5
 #  'ScanSwf':
 #    - positive:
@@ -518,6 +519,7 @@ scanners:
           - 'text/xml'
           - 'xml_file'
           - 'svg_file'
+          - 'image/svg+xml'
           - 'text/calendar'
           - 'application/ics'
       priority: 5
@@ -564,6 +566,7 @@ scanners:
           - 'text/xml'
           - 'xml_file'
           - 'svg_file'
+          - 'image/svg+xml'
           - 'mso_file'
           - 'soap_file'
           - 'html_file' # Simple XML, such as a POM file, is recognized as HTML


### PR DESCRIPTION
**Describe the change**
Adding `image/svg+xml`, as yara tasting can sometimes miss on SVGs.
