### PR TITLE
Upgrade to go 1.24.2 (CVE-2025-22871)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module strelka-frontend
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/go-redis/redis/v8 v8.11.4


### PR DESCRIPTION
Upgrade to go 1.24.2 (CVE-2025-22871)

https://www.notion.so/sublimesecurity/Upgrade-to-Go-1-24-2-CVE-2025-22871-1c804655fc9d800499aeca58e70398a2?pvs=4
