### PR TITLE
Gracefully shutdown on SIGINT for FE/BE/Manager

### DIFF
--- a/src/go/cmd/strelka-manager/main.go
+++ b/src/go/cmd/strelka-manager/main.go
@@ -52,6 +52,7 @@ func main() {
 		select {
 		case <-shutdownWorkersSig:
 			log.Printf("Received shutdown signal, exiting.")
+			return
 		default:
 		}
 

--- a/src/go/cmd/strelka-manager/main.go
+++ b/src/go/cmd/strelka-manager/main.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -41,10 +44,19 @@ func main() {
 		log.Fatalf("failed to connect to coordinator: %v", err)
 	}
 
+	var shutdownWorkersSig = make(chan os.Signal, 1)
+	signal.Notify(shutdownWorkersSig, syscall.SIGINT)
+
 	// TODO: this should be a goroutine
 	for {
+		select {
+		case <-shutdownWorkersSig:
+			log.Printf("Received shutdown signal, exiting.")
+		default:
+		}
+
 		zrem, err := cd.ZRemRangeByScore(
-		    cd.Context(),
+			cd.Context(),
 			"tasks",
 			"-inf",
 			fmt.Sprintf("(%v", time.Now().Unix()),

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -17,6 +17,8 @@ import re
 import string
 import sys
 import time
+import signal
+import threading
 
 import inflection
 import interruptingcow
@@ -27,8 +29,10 @@ import yara
 
 from strelka import strelka, yara_extern
 
+shutdown_event = threading.Event()
 
 class Backend(object):
+
     def __init__(self, backend_cfg, coordinator):
         self.scanner_cache = {}
         self.backend_cfg = backend_cfg
@@ -70,7 +74,7 @@ class Backend(object):
         work_start = time.time()
         work_expire = work_start + self.limits.get('time_to_live')
 
-        while 1:
+        while not shutdown_event.is_set():
             if self.limits.get('max_files') != 0:
                 if count >= self.limits.get('max_files'):
                     break
@@ -89,6 +93,12 @@ class Backend(object):
 
             if timeout <= 0:
                 continue
+
+            if shutdown_event.is_set():
+                logging.info(f'Received task after shutdown signal, re-queuing {task}.')
+                # We picked up a task after shutdown_event was set. We'll put it back on the queue for another worker
+                self.coordinator.zadd(queue_name, {root_id: expire_at})
+                break
 
             if queue_name == b'tasks':
                 file = strelka.File(pointer=root_id)
@@ -151,7 +161,8 @@ class Backend(object):
 
         logging.info(f'shutdown after scanning {count} file(s),'
                      f' syncing {synced} yara files, and'
-                     f' {time.time() - work_start} second(s)')
+                     f' {time.time() - work_start} second(s)'
+                     f' should shutdown trigger: {shutdown_event.is_set()}')
 
     def compile_yara(self, root_id):
         data = b''
@@ -439,8 +450,14 @@ class Backend(object):
                     return assigned
         return None
 
+def handle_sigint(signum, frame):
+    logging.info('Received SIGINT. Will attempt to finish any current tasks before shutting down.')
+    shutdown_event.set()
+
 
 def main():
+    signal.signal(signal.SIGINT, handle_sigint)
+
     parser = argparse.ArgumentParser(prog='strelka-worker',
                                      description='runs Strelka workers',
                                      usage='%(prog)s [options]')


### PR DESCRIPTION
**Describe the change**
Handle `SIGINT` signals in all services to allow auto scaling down gracefully.


**Describe testing procedures**

## Backend
* Updated my local docker compose to use SIGINT, not SIGKILL for shutdown.
* Tested regular idle shutdown
  * Exited w/ status code `0` after a few seconds (due to blocking `bzpopmin` call)
* Validated requeing behavior: 
  * Initiated shutdown via docker
  * Sent a task to the Strelka queue
  * Saw `Received task after shutdown signal, re-queuing` message, and then a clean shutdown
  * Restarted backend container
  * Task was picked up and processed.

We generally send tasks with a 1 minute timeout, so we'll want to allow a full minute for graceful shutdown (probably plus a little buffer).

## Frontend

I simply just validated that the signal was received and resulted in shutdown down w/ exit code `0`. GRPC docs say the following about the graceful shutdown method:

```
// GracefulStop stops the gRPC server gracefully. It stops the server from
// accepting new connections and RPCs and blocks until all the pending RPCs are
// finished.
```

but I did not validate this behavior.

## Manager
I simply just validated that the signal was received and resulted in shutdown down w/ exit code `0`

