### PR TITLE
Add ScanMht scanner

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -308,6 +308,11 @@ scanners:
         flavors:
           - 'browser_manifest'
       priority: 5
+  'ScanMht':
+    - positive:
+        flavors:
+          - 'mhtml_file'
+      priority: 5
 #  'ScanMmbot':
 #    - positive:
 #        flavors:

--- a/build/configs/taste.yara
+++ b/build/configs/taste.yara
@@ -81,10 +81,13 @@ rule mhtml_file {
     meta:
         type = "archive"
     strings:
-        $a = "MIME-Version: 1.0"
-        $b = "This document is a Single File Web Page, also known as a Web Archive file"
+        $mime_version = "MIME-Version: 1.0"
+        $boundary_def = "boundary="
+        $content_type = "Content-Type:"
+        $archive_text = "This document is a Single File Web Page, also known as a Web Archive file"
     condition:
-        $a at 0 and $b
+        $mime_version at 0 and 
+        ($archive_text or ($boundary_def in (0..500) and #content_type >= 2))
 }
 
 rule rar_file {

--- a/src/python/strelka/scanners/scan_mht.py
+++ b/src/python/strelka/scanners/scan_mht.py
@@ -1,0 +1,81 @@
+import email
+
+from strelka import strelka
+
+
+class ScanMht(strelka.Scanner):
+    """Extracts embedded files from MHT (MHTML) archives.
+
+    This scanner processes MHTML files and extracts embedded content.
+    Focuses on speed - extracts parts quickly with all headers captured.
+    
+    Dependencies:
+        - Standard library modules (email)
+    """
+
+    def scan(self, data, file, options, expire_at):
+        self.event["total"] = {"extracted": 0, "parts": 0}
+        
+        try:
+            # Parse the MHT file as an email message (MIME format)
+            message = email.message_from_string(data.decode('utf-8', errors='ignore'))
+            
+            # Capture all main message headers
+            self.event['headers'] = dict(message.items())
+            
+            # Extract boundary value if present
+            boundary = message.get_boundary()
+            if boundary:
+                self.event['boundary'] = boundary
+            
+            part_count = 0
+            self.event['parts'] = []
+            
+            # Process all parts of the multipart message
+            for part in message.walk():
+                self.event['total']['parts'] += 1
+                
+                # Skip the root multipart container
+                if part.get_content_maintype() == 'multipart':
+                    continue
+                
+                # Get the payload with automatic decoding
+                decoded_data = part.get_payload(decode=True)
+                if not decoded_data or len(decoded_data) < 10:
+                    continue
+                
+                # Capture all part headers
+                part_headers = dict(part.items())
+                self.event['parts'].append(part_headers)
+                
+                # Create extracted file with static naming
+                extract_file = strelka.File(
+                    name=f'mht_part_{part_count}',
+                    source=self.name,
+                )
+                
+                # Add content type flavor if available
+                content_type = part.get_content_type()
+                if content_type:
+                    extract_file.add_flavors({'external': [content_type]})
+                
+                # Upload the decoded data
+                for c in strelka.chunk_string(decoded_data):
+                    self.upload_to_coordinator(
+                        extract_file.pointer,
+                        c,
+                        expire_at,
+                    )
+                
+                self.files.append(extract_file)
+                self.event['total']['extracted'] += 1
+                part_count += 1
+            
+            # Set flags based on extraction results
+            if self.event['total']['extracted'] == 0:
+                self.flags.append('no_content_extracted')
+
+        except UnicodeDecodeError:
+            self.flags.append('unicode_decode_error')
+        except Exception as e:
+            self.flags.append('mht_extraction_error')


### PR DESCRIPTION
**Describe the change**
Adds support for MHT file exploding and metadata generation via a `ScanMht` scanner.  This scanner uses an python builtin `email` for the parsing of the MHT file

This required updating of the taste yara rule for `mhtml_file` to account for the observed file format which lacked the "archive_text" condition. 

The ScanMht scanner does introduce new fields into the strelka output that might require changes within other sublime-platform elements.  Specially there are objects in the json output of Strelka (below) which are not represented within the output of file.explode within the product. Adding these elements to the output of file.explode is not a blocking requirement. 

The below JSON is the output of strelka as a result of the MHT file. 
```
{
    "mht": {
        "boundary": "----=mhtDocumentPart",
        "elapsed": 0.001343,
        "headers": {
            "Content-Type": "multipart/related;\n    type=\"text/html\";\n    boundary=\"----=mhtDocumentPart\"",
            "MIME-Version": "1.0"
        },
        "parts": [
            {
                "Content-Location": "file:///C:/test/document.html",
                "Content-Transfer-Encoding": "quoted-printable",
                "Content-Type": "text/html;\n    charset=\"utf-8\""
            },
            {
                "Content-Location": "file:///C:/test/image0.png",
                "Content-Transfer-Encoding": "base64",
                "Content-Type": "image/png"
            },
            {
                "Content-Location": "file:///C:/test/image1.png",
                "Content-Transfer-Encoding": "base64",
                "Content-Type": "image/png"
            }
        ],
        "total": {
            "extracted": 3,
            "parts": 4
        }
    }
}
```

---

**Describe testing procedures**
Image Creation
1) edited the files locally within the sublime-security fork of strelka
2) built a new strelka image from that repo 
3) updated the docker-compose within sublime-platform repo to use the local image for the `sublime_strelka_backend` service
4) ran a `docker compose up -d` from sublime-platform 
5) observed the recreated containers running the newly created image 

End to End
1) Logged into the locally running instance
2) using the EML analyzer built an email with an attached docx with a nested mht file
3) examined the file explode output of the attached document 
4) observed the exploded image and html file at the correct depth within the file explode output with the correct child/parent ids (see screenshots below)

**Sample output**
The two screenshots below show the parent/child relationship and the results of the exploded files from the MHT file.  
Note: Also observed is the lack of the .mht element under the .scan for the MHT file. 

![image](https://github.com/user-attachments/assets/3fb8d7de-fe76-40ce-90b2-9aacbd936ea1)
![image](https://github.com/user-attachments/assets/a23c824e-3252-478c-a4a9-5b3a5f6ec9d8)


**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
