### PR TITLE
Improving embedded JS handling

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -248,6 +248,7 @@ scanners:
         flavors:
           - 'javascript_file'
           - 'text/javascript'
+          - 'application/ecmascript'
       priority: 5
       options:
         beautify: True

--- a/src/python/strelka/scanners/scan_html.py
+++ b/src/python/strelka/scanners/scan_html.py
@@ -106,6 +106,7 @@ class ScanHtml(strelka.Scanner):
                 script_flavors = [
                     script.get('language', '').lower(),
                     script.get('type', '').lower(),
+                    'text/javascript',
                 ]
                 script_entry = {
                     'src': script.get('src'),

--- a/src/python/strelka/scanners/scan_xml.py
+++ b/src/python/strelka/scanners/scan_xml.py
@@ -6,6 +6,8 @@ from strelka import strelka
 class ScanXml(strelka.Scanner):
     """Collects metadata and extracts embedded files from XML files.
 
+    Extracts JavaScript content from script tags and emits them as child files.
+
     Options:
         extract_tags: List of XML tags that will have their text extracted
             as child files.
@@ -23,7 +25,8 @@ class ScanXml(strelka.Scanner):
         self.event.setdefault('tags', [])
         self.event.setdefault('tag_data', [])
         self.event.setdefault('namespaces', [])
-        self.event['total'] = {'tags': 0, 'extracted': 0}
+        self.event.setdefault('scripts', [])
+        self.event['total'] = {'tags': 0, 'scripts': 0, 'extracted': 0}
 
         xml = None
         try:
@@ -78,6 +81,36 @@ class ScanXml(strelka.Scanner):
                             name=tag,
                             source=self.name,
                         )
+
+                        for c in strelka.chunk_string(text):
+                            self.upload_to_coordinator(
+                                extract_file.pointer,
+                                c,
+                                self.expire_at,
+                            )
+
+                        self.files.append(extract_file)
+                        self.event['total']['extracted'] += 1
+
+                # Check for script tags and extract JavaScript content
+                if tag == 'script':
+                    self.event['total']['scripts'] += 1
+                    script_entry = {
+                        'type': node.attrib.get('type'),
+                        'src': node.attrib.get('src'),
+                    }
+                    if script_entry not in self.event['scripts']:
+                        self.event['scripts'].append(script_entry)
+
+                    if text and text.strip():
+                        extract_file = strelka.File(
+                            name=f'script_{self.event["total"]["scripts"]-1}',
+                            source=self.name,
+                        )
+                        script_flavors = [
+                            node.attrib.get('type', '').lower(),
+                        ]
+                        extract_file.add_flavors({'external': script_flavors})
 
                         for c in strelka.chunk_string(text):
                             self.upload_to_coordinator(


### PR DESCRIPTION
**Describe the change**
Added JS extraction to the SVG scanner, and improved on the HTML scanner to ensure extracted JS is scanned with ScanJavascript.


**Describe testing procedures**
Tested locally (built local Strelka)

**Sample output**
- HTML with embedded JS
<img width="468" alt="Screenshot 2025-06-18 at 10 28 23 AM" src="https://github.com/user-attachments/assets/e7484b5e-0a95-4b1a-8bbc-a42423c12bce" />

- SVG with embedded JS
<img width="1052" alt="Screenshot 2025-06-18 at 10 30 30 AM" src="https://github.com/user-attachments/assets/badc1879-3a94-4f67-be69-369536aa3c99" />
