### PR TITLE
Address critical CVEs with backend image

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -1,5 +1,4 @@
-#FROM ubuntu:24.04
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
@@ -126,7 +125,7 @@ RUN wget https://github.com/tesseract-ocr/tessdata/raw/main/eng.traineddata && m
 
 # Install Python packages
 COPY ./build/python/backend/requirements.txt /strelka/requirements.txt
-RUN pip3 install --no-cache-dir -r /strelka/requirements.txt
+RUN pip3 install --no-cache-dir --break-system-packages -r /strelka/requirements.txt
 
 # Copy Strelka files
 COPY ./src/python/ /strelka/

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -126,7 +126,7 @@ RUN mkdir tesseract && cd tesseract && git init && git remote add origin https:/
 # Install English support for Tesseract
 RUN wget https://github.com/tesseract-ocr/tessdata/raw/main/eng.traineddata && mv eng.traineddata /usr/local/share/tessdata/
 
-# Install Zbar
+# Install Zbar from binary; 0.23.92 has a critical vulnerability, 0.23.93 must be installed from source or binary
 RUN wget https://github.com/mchehab/zbar/archive/refs/tags/0.23.93.tar.gz && tar -zxvf 0.23.93.tar.gz && mv zbar-0.23.93 /usr/local
 
 # Install Python packages

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:24.04
+#FROM ubuntu:24.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -35,6 +35,10 @@ RUN apt-get -qq update && \
     antiword \
     libarchive-dev \
     libfuzzy-dev \
+    libgssapi-krb5-2=1.19.2-2ubuntu0.7 \
+    libkrb5-3=1.19.2-2ubuntu0.7 \
+    libk5crypto3=1.19.2-2ubuntu0.7 \
+    libkrb5support0=1.19.2-2ubuntu0.7 \
     libmagic-dev \
     libssl-dev \
     libgl1 \

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 
@@ -37,7 +37,6 @@ RUN apt-get -qq update && \
     libfuzzy-dev \
     libmagic-dev \
     libssl-dev \
-    libzbar0 \
     libgl1 \
     python3-setuptools \
     redis-server \
@@ -123,9 +122,12 @@ RUN mkdir tesseract && cd tesseract && git init && git remote add origin https:/
 # Install English support for Tesseract
 RUN wget https://github.com/tesseract-ocr/tessdata/raw/main/eng.traineddata && mv eng.traineddata /usr/local/share/tessdata/
 
+# Install Zbar
+RUN wget https://github.com/mchehab/zbar/archive/refs/tags/0.23.93.tar.gz && tar -zxvf 0.23.93.tar.gz && mv zbar-0.23.93 /usr/local
+
 # Install Python packages
 COPY ./build/python/backend/requirements.txt /strelka/requirements.txt
-RUN pip3 install --no-cache-dir --break-system-packages -r /strelka/requirements.txt
+RUN pip3 install --no-cache-dir -r /strelka/requirements.txt
 
 # Copy Strelka files
 COPY ./src/python/ /strelka/

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -35,10 +35,6 @@ RUN apt-get -qq update && \
     antiword \
     libarchive-dev \
     libfuzzy-dev \
-    libgssapi-krb5-2=1.19.2-2ubuntu0.7 \
-    libkrb5-3=1.19.2-2ubuntu0.7 \
-    libk5crypto3=1.19.2-2ubuntu0.7 \
-    libkrb5support0=1.19.2-2ubuntu0.7 \
     libmagic-dev \
     libssl-dev \
     libgl1 \
@@ -47,6 +43,8 @@ RUN apt-get -qq update && \
     unrar \
     upx \
     jq && \
+# Upgrade packages
+    apt-get -y upgrade && \
 # Download and compile Archive library, needed for exiftool to work best
     cd /tmp/ && \
     curl -OL https://cpan.metacpan.org/authors/id/P/PH/PHRED/Archive-Zip-1.68.tar.gz && \

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -125,6 +125,8 @@ RUN mkdir tesseract && cd tesseract && git init && git remote add origin https:/
 RUN wget https://github.com/tesseract-ocr/tessdata/raw/main/eng.traineddata && mv eng.traineddata /usr/local/share/tessdata/
 
 # Install Zbar from binary; 0.23.92 has a critical vulnerability, 0.23.93 must be installed from source or binary
+# The fixed version is available in the Ubuntu 22.04 main apt repos only with an Ubuntu pro subscription, which we don't have.
+# Once we upgrade to Ubuntu 24.04, we can drop this and go back to `apt install libzbar-dev`.
 RUN wget https://github.com/mchehab/zbar/archive/refs/tags/0.23.93.tar.gz && tar -zxvf 0.23.93.tar.gz && mv zbar-0.23.93 /usr/local
 
 # Install Python packages

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Target Brands, Inc. TTS-CFC-OpenSource@target.com"
 


### PR DESCRIPTION
**Describe the change**
Updates the zbar package to 0.23.93 by installing the package directly from a pre-built release. There are two critical CVEs that are tied to version 0.23.92:

* https://ubuntu.com/security/CVE-2023-40890 - fixed with Ubuntu Pro in 22.04, does not affect 24.04
* https://ubuntu.com/security/CVE-2023-40889 - fixed with Ubuntu Pro in 22.04, does not affect 24.04

However, 0.23.92 is the latest package version available for 22.04 when installing from apt (the fix with Ubuntu Pro is not generally available). This change installs the next version with the CVEs addressed.

This update also addresses https://ubuntu.com/security/CVE-2024-3596 by specifying krb5 package numbers that include fixes for the CVE for all packages currently marked as having a critical vulnerability.

**Describe testing procedures**
Tested via CI and build checks

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
