### PR TITLE
Update installation of zbar package

### DIFF
--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -12,11 +12,13 @@ RUN apt-get -qq update && \
 # Install build packages
     apt-get install --no-install-recommends -qq \
     automake \
+    autopoint \
     build-essential \
     ca-certificates \
     cmake \
     curl \
     gcc \
+    gettext \
     git \
     g++ \
     libglu1-mesa \
@@ -127,7 +129,14 @@ RUN wget https://github.com/tesseract-ocr/tessdata/raw/main/eng.traineddata && m
 # Install Zbar from binary; 0.23.92 has a critical vulnerability, 0.23.93 must be installed from source or binary
 # The fixed version is available in the Ubuntu 22.04 main apt repos only with an Ubuntu pro subscription, which we don't have.
 # Once we upgrade to Ubuntu 24.04, we can drop this and go back to `apt install libzbar-dev`.
-RUN wget https://github.com/mchehab/zbar/archive/refs/tags/0.23.93.tar.gz && tar -zxvf 0.23.93.tar.gz && mv zbar-0.23.93 /usr/local
+RUN wget https://github.com/mchehab/zbar/archive/refs/tags/0.23.93.tar.gz && \
+    tar -zxvf 0.23.93.tar.gz && \
+    cd zbar-0.23.93 && \
+    autoreconf -vfi && \
+    ./configure && \
+    make && \
+    make install && \
+    cd ..
 
 # Install Python packages
 COPY ./build/python/backend/requirements.txt /strelka/requirements.txt


### PR DESCRIPTION
**Describe the change**
Addresses an installation bug from https://github.com/sublime-security/strelka/pull/126 that was exposed during release testing for 0.3.78. With this fix, tests do not fail with errors about the zbar installation not being found.

**Describe testing procedures**
Validated test outputs before and after fix locally; with the fix applied, errors about zbar installation disappear.

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
