### PR TITLE
Updates lief version to address security vulnerability

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -15,12 +15,7 @@ inflection==0.5.1
 interruptingcow==0.8
 jsbeautifier==1.13.13
 libarchive-c==2.9
-
-
-# lief doesn't have prebuilt binaries for ARM64 in PyPi, use our own prebuilt binary
-https://sublime-python-deps.s3.amazonaws.com/lief-0.12.3-cp310-cp310-linux_aarch64.whl; sys_platform == 'linux' and (platform_machine == 'arm64' or platform_machine == 'aarch64')
-lief==0.13.2; sys_platform != 'linux' or (platform_machine != 'arm64' and platform_machine != 'aarch64')
-
+lief==0.15.1
 lxml==4.9.1
 M2Crypto==0.38.0
 nested-lookup==0.2.22


### PR DESCRIPTION
**Describe the change**
Updates lief version to 0.15.1, to address https://github.com/sublime-security/strelka/security/dependabot/4. Dependabot couldn't create the PR itself - my guess is because of the old logic we had regarding lief versions and deployments. However, lief now supports arm64, so I've removed the deployment-specific logic and put the version to 0.15.1 (which addresses the vulnerability).

**Describe testing procedures**
Validated with local rebuild, will also validate with CI

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
