### PR TITLE
Revert "Updates lief version to address security vulnerability (#134)"

### DIFF
--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -15,7 +15,12 @@ inflection==0.5.1
 interruptingcow==0.8
 jsbeautifier==1.13.13
 libarchive-c==2.9
-lief==0.15.1
+
+
+# lief doesn't have prebuilt binaries for ARM64 in PyPi, use our own prebuilt binary
+https://sublime-python-deps.s3.amazonaws.com/lief-0.12.3-cp310-cp310-linux_aarch64.whl; sys_platform == 'linux' and (platform_machine == 'arm64' or platform_machine == 'aarch64')
+lief==0.13.2; sys_platform != 'linux' or (platform_machine != 'arm64' and platform_machine != 'aarch64')
+
 lxml==4.9.1
 M2Crypto==0.38.0
 nested-lookup==0.2.22


### PR DESCRIPTION
This reverts commit 5f6b5ea4a4df082570be3934114a6a4aaafd9ddc.

**Describe the change**
There was a test not exercised by CI when updating Lief to address a vulnerability. This reverts that change.

**Describe testing procedures**
Reran strelka file tests - specifically, the Mach0 file test which fails with the Lief upgrade.

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
