### PR TITLE
Add ScanTranscode - Image conversion

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -533,8 +533,11 @@ scanners:
           - 'image/svg+xml'
       priority: 5
       options:
-        output_format: 'jpeg'
-        max_file_size: 5242880  # 5MB in bytes
+        svg_output_format: 'png'     # SVG optimized for PNG (lossless vector→raster)
+        heif_output_format: 'jpeg'   # HEIF optimized for JPEG (photos, smaller files)
+        avif_output_format: 'jpeg'   # AVIF optimized for JPEG (photos, smaller files)
+        output_format: 'png'         # General fallback format
+        max_file_size: 5242880       # 5MB in bytes
 #  'ScanTnef': Proprietary email format https://en.wikipedia.org/wiki/Transport_Neutral_Encapsulation_Format
 #    - positive:
 #        flavors:

--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -257,6 +257,9 @@ scanners:
         flavors:
           - 'image/jpeg'
           - 'jpeg_file'
+      negative:
+        source:
+          - 'ScanTranscode'
       priority: 5
 #  'ScanJson':
 #    - positive:
@@ -517,6 +520,21 @@ scanners:
       priority: 5
       options:
         limit: 1000
+  'ScanTranscode':
+    - positive:
+        flavors:
+          - 'heif_file'
+          - 'heic_file'
+          - 'avif_file'
+          - 'image/heif'
+          - 'image/heic'
+          - 'image/avif'
+          - 'svg_file'
+          - 'image/svg+xml'
+      priority: 5
+      options:
+        output_format: 'jpeg'
+        max_file_size: 5242880  # 5MB in bytes
 #  'ScanTnef': Proprietary email format https://en.wikipedia.org/wiki/Transport_Neutral_Encapsulation_Format
 #    - positive:
 #        flavors:

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -21,11 +21,13 @@ RUN apt-get -qq update && \
     gettext \
     git \
     g++ \
+    libavif-dev \
     libglu1-mesa \
     libleptonica-dev \
     libpango1.0-dev \
     libtool \
     make \
+    nasm \
     swig \
     tesseract-ocr-eng \
     python3-dev \
@@ -36,6 +38,7 @@ RUN apt-get -qq update && \
 # Install runtime packages
     antiword \
     libarchive-dev \
+    libavif15 \
     libfuzzy-dev \
     libmagic-dev \
     libssl-dev \

--- a/build/python/backend/Dockerfile
+++ b/build/python/backend/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get -qq update && \
 # Install runtime packages
     antiword \
     libarchive-dev \
-    libavif15 \
+    libavif13 \
     libfuzzy-dev \
     libmagic-dev \
     libssl-dev \

--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -29,6 +29,9 @@ olefile==0.46
 oletools==0.60.1
 opencv-python==4.8.1.78
 opencv-contrib-python==4.8.1.78
+Pillow>=9.0.0
+pillow-avif>=1.3.0
+pillow-heif>=0.10.0
 idna==3.10
 PyMuPDF==1.23.5
 pefile==2019.4.18

--- a/build/python/backend/requirements.txt
+++ b/build/python/backend/requirements.txt
@@ -29,8 +29,7 @@ olefile==0.46
 oletools==0.60.1
 opencv-python==4.8.1.78
 opencv-contrib-python==4.8.1.78
-Pillow>=9.0.0
-pillow-avif>=1.3.0
+Pillow>=11.2.1
 pillow-heif>=0.10.0
 idna==3.10
 PyMuPDF==1.23.5

--- a/src/python/bin/strelka-backend
+++ b/src/python/bin/strelka-backend
@@ -422,10 +422,10 @@ class Backend(object):
             positives = mapping.get('positive', {})
             neg_flavors = negatives.get('flavors', [])
             neg_filename = negatives.get('filename', None)
-            neg_source = negatives.get('source', None)
+            neg_source = negatives.get('source', [])
             pos_flavors = positives.get('flavors', [])
             pos_filename = positives.get('filename', None)
-            pos_source = positives.get('source', None)
+            pos_source = positives.get('source', [])
             assigned = {'name': scanner,
                         'priority': mapping.get('priority', 5),
                         'options': mapping.get('options', {})}
@@ -433,20 +433,21 @@ class Backend(object):
             for neg_flavor in neg_flavors:
                 if neg_flavor in flavors:
                     return None
-            if neg_filename is not None:
-                if re.search(neg_filename, file.name) is not None:
-                    return None
-            if neg_source is not None:
-                if re.search(neg_source, file.source) is not None:
-                    return None
+            if neg_filename:
+                if re.search(neg_filename, file.name):
+                    return {}
+            if neg_source:
+                print(file.source, neg_source)
+                if file.source in neg_source:
+                    return {}
             for pos_flavor in pos_flavors:
                 if pos_flavor == '*' or pos_flavor in flavors:
                     return assigned
-            if pos_filename is not None:
-                if re.search(pos_filename, file.name) is not None:
+            if pos_filename:
+                if re.search(pos_filename, file.name):
                     return assigned
-            if pos_source is not None:
-                if re.search(pos_source, file.source) is not None:
+            if pos_source:
+                if file.source in pos_source:
                     return assigned
         return None
 

--- a/src/python/strelka/scanners/scan_transcode.py
+++ b/src/python/strelka/scanners/scan_transcode.py
@@ -75,10 +75,12 @@ class ScanTranscode(strelka.Scanner):
             if is_svg:
                 converted_image = convert_svg_with_pymupdf(data)
                 output_format = svg_output_format
+                input_format = "svg"
             else:
                 # Determine output format based on input format
                 img = Image.open(io.BytesIO(data))
                 if hasattr(img, 'format') and img.format:
+                    input_format = img.format.lower()
                     if img.format.upper() in ['HEIF', 'HEIC']:
                         output_format = heif_output_format
                     elif img.format.upper() == 'AVIF':
@@ -86,13 +88,14 @@ class ScanTranscode(strelka.Scanner):
                     else:
                         output_format = default_output_format
                 else:
+                    input_format = "unknown"
                     output_format = default_output_format
                 
                 converted_image = convert_with_pillow(img, output_format)
 
-            # Create extracted file for local Strelka framework
+            # Create descriptive filename following PDF scanner pattern
             extract_file = strelka.File(
-                name=file.name,
+                name=f"transcode_{input_format}_2_{output_format.lower()}",
                 source=self.name,
             )
 

--- a/src/python/strelka/scanners/scan_transcode.py
+++ b/src/python/strelka/scanners/scan_transcode.py
@@ -2,7 +2,6 @@ import io
 import logging
 
 import fitz  # PyMuPDF
-import pillow_avif
 from PIL import Image, UnidentifiedImageError
 from pillow_heif import register_heif_opener
 
@@ -10,9 +9,7 @@ from strelka import strelka
 
 logging.getLogger("PIL").setLevel(logging.WARNING)
 
-# Must be imported as a plugin, doesn't need to be used
-_ = pillow_avif.AvifImagePlugin
-
+# Register HEIF support
 register_heif_opener()
 
 

--- a/src/python/strelka/scanners/scan_transcode.py
+++ b/src/python/strelka/scanners/scan_transcode.py
@@ -1,0 +1,102 @@
+import io
+import logging
+
+import fitz  # PyMuPDF
+import pillow_avif
+from PIL import Image, UnidentifiedImageError
+from pillow_heif import register_heif_opener
+
+from strelka import strelka
+
+logging.getLogger("PIL").setLevel(logging.WARNING)
+
+# Must be imported as a plugin, doesn't need to be used
+_ = pillow_avif.AvifImagePlugin
+
+register_heif_opener()
+
+
+class ScanTranscode(strelka.Scanner):
+    """
+    Converts supported images for easier scanning
+
+    Supports HEIF, HEIC, AVIF (via Pillow) and SVG (via PyMuPDF)
+    Typical supported output options: gif webp jpeg bmp png tiff
+    """
+
+    def scan(self, data, file, options, expire_at):
+        output_format = options.get("output_format", "jpeg")
+        max_file_size = options.get("max_file_size", 5 * 1024 * 1024)  # Default 5MB
+        
+        # Check file size limit
+        if len(data) > max_file_size:
+            self.flags.append("file_too_large")
+            self.event["file_size"] = len(data)
+            self.event["max_file_size"] = max_file_size
+            return
+
+        def convert_with_pillow(im):
+            with io.BytesIO() as f:
+                im.save(f, format=f"{output_format}", quality=90)
+                return f.getvalue()
+
+        def convert_svg_with_pymupdf(svg_data):
+            """Convert SVG to PNG using PyMuPDF
+            
+            Note: SVG files are always rendered to PNG first via PyMuPDF,
+            then optionally converted to the specified output_format via Pillow
+            """
+            try:
+                # Create a document from SVG data
+                doc = fitz.open("svg", svg_data)
+                page = doc[0]
+                
+                # Render page to a pixmap (default is PNG format)
+                pix = page.get_pixmap()
+                png_data = pix.tobytes("png")
+                doc.close()
+                
+                # If output format is not PNG, convert using Pillow
+                if output_format.lower() != "png":
+                    img = Image.open(io.BytesIO(png_data))
+                    return convert_with_pillow(img)
+                else:
+                    return png_data
+            except Exception:
+                raise UnidentifiedImageError("Failed to convert SVG")
+
+        # Check if this is an SVG file
+        is_svg = (b'<svg' in data[:1000].lower() or 
+                 b'<?xml' in data[:100] and b'<svg' in data[:2000].lower())
+
+        try:
+            if is_svg:
+                converted_image = convert_svg_with_pymupdf(data)
+            else:
+                # Use Pillow for other formats (HEIF, HEIC, AVIF, etc.)
+                converted_image = convert_with_pillow(Image.open(io.BytesIO(data)))
+
+            # Create extracted file for local Strelka framework
+            extract_file = strelka.File(
+                name=file.name,
+                source=self.name,
+            )
+
+            # Upload the converted image data to coordinator
+            for chunk in strelka.chunk_string(converted_image):
+                self.upload_to_coordinator(
+                    extract_file.pointer,
+                    chunk,
+                    expire_at,
+                )
+
+            self.files.append(extract_file)
+
+        except UnidentifiedImageError:
+            self.flags.append("unidentified_image")
+            return
+        except Exception:
+            self.flags.append("conversion_error")
+            return
+
+        self.flags.append("transcoded")


### PR DESCRIPTION
# Change Description 
Largely taken from/inspired by the upstream [scan_transcode.py](https://github.com/target/strelka/blob/master/src/python/strelka/scanners/scan_transcode.py) this adds support for converting SVG, HEIF/HEIC and AVIF files to JPG/PNG formats and sending them back into strelka.  
This change allows these image types when attached to be converted to support OCR and QR code inspection. 

Actors have been observed using these image types to send QR codes leading to credential phishing  and callback phishing via attachments. 

#Testing Prodedures
## Image Creation
- via git checked out the zoomequipd.scan_transcode branch within the sublime-security fork of strelka
- built a new strelka image from that repo
- updated the docker-compose within sublime-platform repo to use the local image for the sublime_strelka_backend service
- ran a docker compose up -d from sublime-platform
- observed the recreated containers running the newly created image

## End to End
- Logged into the locally running instance
- using the EML analyzer built an email with an attached attached SVG of a QR code
- examined the file explode output of the attached document
- observed the exploded image and converted PNG file at the correct depth within the file explode output with the correct child/parent ids (see screenshots below)

# Sample Output
## SVG Files
The screenshot below shows the parent/child node relationship of the attached SVG and resulting PNG along with the QR code being decoded. 
<img width="869" height="822" alt="image" src="https://github.com/user-attachments/assets/0e1da0d9-8ca0-4987-b013-78b5a3d79167" />

## HEIF Files
The screenshot below shows the parent/child node relationship of the attached heic and resulting JPG along with the OCR output being generated. 
<img width="869" height="822" alt="image" src="https://github.com/user-attachments/assets/c83a6ccf-dce0-4891-aacb-7972506e8311" />

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
