### PR TITLE
Adding .raw output to scanned strings

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -501,6 +501,8 @@ scanners:
           - 'svg_file'
           - 'image/svg+xml'
       priority: 5
+      options:
+        enable_raw: True
 #  'ScanSwf':
 #    - positive:
 #        flavors:

--- a/src/python/strelka/scanners/scan_strings.py
+++ b/src/python/strelka/scanners/scan_strings.py
@@ -20,6 +20,16 @@ class ScanStrings(strelka.Scanner):
 
     def scan(self, data, file, options, expire_at):
         limit = options.get('limit', 0)
+        enable_raw = options.get('enable_raw', False)
+        if enable_raw:
+            try: 
+                raw = data.decode("utf-8")
+                if isinstance(raw, str):
+                    self.event['raw'] = raw
+            except UnicodeDecodeError:
+                self.flags.append(f"unicode_decode_error_{file.uid}")
+            except ValueError:
+                self.flags.append(f"value_error_{file.uid}")
 
         strings = self.strings_regex.findall(data)
         if limit:


### PR DESCRIPTION
**Describe the change**
Add option for when a file is all plain text, returning the text as a single raw string. The existing scan strings scanner produces an output array of strings. This proposed change introduces a new field `.raw` which produces the output as a single string. 

This functionality is limited to when the output can be successfully decoded in the resulting object is a `str` instance.

**Describe testing procedures**
**Image Creation**
- via git checked out the test branch within the sublime-security fork of strelka
- built a new strelka image from that repo
- updated the docker-compose within sublime-platform repo to use the local image for the sublime_strelka_backend service
- ran a docker compose up -d from sublime-platform
observed the recreated containers running the newly created image
**End to End**
- Logged into the locally running instance
- using the EML analyzer built an email with an attached .text code
- examined the file explode output of the attached document
- observed the exploded image and converted PNG file at the correct depth within the file explode output with the correct child/parent ids (see screenshots below)

**Sample output**
This adds a new field in scanned strings output, we will be adding functionality to make this new field appear within `file.explode` results, once this functionality is in production.
<img width="2088" height="365" alt="Screenshot 2025-07-29 at 4 37 49 PM" src="https://github.com/user-attachments/assets/04196136-7768-43cf-9b68-30734cb349f5" />

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
