### PR TITLE
add ics/calendar files back to scanStrings

### DIFF
--- a/build/configs/scanners.yaml
+++ b/build/configs/scanners.yaml
@@ -502,6 +502,8 @@ scanners:
           - 'plist_file'
           - 'rtf_file'
           - 'soap_file'
+          - 'text/calendar'
+          - 'application/ics'
           - 'text/html'
           - 'text/plain'
           - 'text/rtf'


### PR DESCRIPTION
**Describe the change**
#141  removed ICS from scanStrings.  However, this removed additional scanners from scanning the strings of the file (such as the scanURL and scanJavascript modules) 

This PR adds the file types back into the scanStrings scanner.

**Describe testing procedures**
deployed the changes locally and submitted an ICS file and ensured that the strings output was included. 

**Sample output**
N/A

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of and tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
