### PR TITLE
Parse URLS from ICS string fields

### DIFF
--- a/src/python/strelka/tests/fixtures/test_phishing.ics
+++ b/src/python/strelka/tests/fixtures/test_phishing.ics
@@ -1,0 +1,43 @@
+BEGIN:VCALENDAR
+METHOD:REQUEST
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Greenwich Standard Time
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=ACME Corp Share-File;SENT-BY="mailto:jsmith@example.com":mailto:AcmeCorp
+ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN=ACME Corp IT Help Desk:mailto:helpdesk@example.com
+ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN=John Smith:mailto:jsmith@example.com
+DESCRIPTION;LANGUAGE=en-US:Good morning\,\n\nIs this phishing?\n\n\nBest\,\n\n\nJohn Smith\, Manager\, People & Culture\n\nACME Corporation\n\n123 Main Street\, Ste. 200 | Seattle\, WA 98121\n\nWorking remotely\n\nC: 555.555.5555\n\njsmith@example.com<mailto:jsmith@example.com>\n\nexample.com\n\nStay in touch with ACME Corp on Facebook<https://www.facebook.com/example> and LinkedIn<http://www.linkedin.com/company/example>\n\nBest Workplaces Award Winner\n\n________________________________\nFrom: attacker@malicious-domain.org <attacker@malicious-domain.org> on behalf of ACME Corp Share-File <AcmeCorp>\nSent: Wednesday\, January 14\, 2026 10:57 AM\nTo: John Smith <jsmith@example.com>\nSubject: Reminder - 2026 Annual Work Report\nWhen: Wednesday\, January 14\, 2026 10:56 AM-10:56 AM.\nWhere: Conference Room\n\n\n\n\n2026 ACME Corp File\nWork_Order_Authorization_Form_2026-01-14.pdf\n25 KB\nOpen<https://malicious-phishing-site.lambda-url.us-east-1.on.aws/?e=dGVzdEBleGFtcGxlLmNvbQ==>\nJob expires on January 16\, 2026\n\n\n\n\n
+UID:test-uid-12345-phishing-ics
+SUMMARY;LANGUAGE=en-US:Fw: Reminder - 2026 Annual Work Report 
+DTSTART;TZID=Greenwich Standard Time:20260114T185653
+DTEND;TZID=Greenwich Standard Time:20260114T185653
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20260114T185553Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION;LANGUAGE=en-US:Conference Room
+X-MICROSOFT-CDO-BUSYSTATUS:TENTATIVE
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:0
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-REQUESTEDATTENDANCEMODE:DEFAULT
+X-MICROSOFT-ISRESPONSEREQUEUTED:TRUE
+END:VEVENT
+END:VCALENDAR

--- a/src/python/strelka/tests/test_scan_ics.py
+++ b/src/python/strelka/tests/test_scan_ics.py
@@ -1,0 +1,204 @@
+"""
+Tests for ScanIcs scanner.
+Run with: python -m pytest src/python/strelka/tests/test_scan_ics.py -v
+"""
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from strelka.scanners.scan_ics import ScanIcs
+from strelka import strelka
+
+
+class TestScanIcs:
+    """Tests for ScanIcs scanner."""
+
+    @pytest.fixture
+    def fixture_path(self):
+        return Path(__file__).parent / "fixtures/test_phishing.ics"
+
+    @pytest.fixture
+    def ics_data(self, fixture_path):
+        with open(fixture_path, "rb") as f:
+            return f.read()
+
+    @pytest.fixture
+    def scanner(self):
+        """Create a scanner instance with mocked dependencies."""
+        backend_cfg = {"limits": {"scanner": 30}}
+        mock_coordinator = mock.MagicMock()
+        scanner = ScanIcs(backend_cfg, mock_coordinator)
+        scanner.upload_to_coordinator = mock.MagicMock()
+        return scanner
+
+    def run_scan(self, scanner, ics_data):
+        """Run the scanner and return the event."""
+        file = strelka.File(name="test.ics")
+        files, event = scanner.scan_wrapper(
+            data=ics_data,
+            file=file,
+            options={},
+            expire_at=0
+        )
+        return event.get("ics", {})
+
+    def test_calendar_metadata(self, scanner, ics_data):
+        """Test that calendar metadata is correctly extracted."""
+        event = self.run_scan(scanner, ics_data)
+
+        assert len(event.get("calendars", [])) == 1
+        cal = event["calendars"][0]
+
+        assert cal.get("prodid") == "Microsoft Exchange Server 2010"
+        assert cal.get("version") == "2.0"
+        assert cal.get("method") == "REQUEST"
+
+    def test_component_counts(self, scanner, ics_data):
+        """Test that component counts are accurate."""
+        event = self.run_scan(scanner, ics_data)
+
+        totals = event.get("total", {})
+        assert totals.get("events") == 1
+        assert totals.get("timezones") == 1
+        assert totals.get("attendees") == 2
+        assert totals.get("organizers") == 1
+
+    def test_vevent_metadata(self, scanner, ics_data):
+        """Test that VEVENT metadata is correctly extracted."""
+        event = self.run_scan(scanner, ics_data)
+
+        # Find the VEVENT component
+        vevent = None
+        for comp in event["calendars"][0]["components"]:
+            if comp.get("type") == "VEVENT":
+                vevent = comp
+                break
+
+        assert vevent is not None
+        assert vevent.get("summary") == "Fw: Reminder - 2026 Annual Work Report "
+        assert vevent.get("uid") == "test-uid-12345-phishing-ics"
+        assert vevent.get("location") == "Conference Room"
+        assert vevent.get("status") == "CONFIRMED"
+
+    def test_attendee_extraction(self, scanner, ics_data):
+        """Test that attendees are correctly extracted."""
+        event = self.run_scan(scanner, ics_data)
+
+        vevent = None
+        for comp in event["calendars"][0]["components"]:
+            if comp.get("type") == "VEVENT":
+                vevent = comp
+                break
+
+        attendees = vevent.get("attendees", [])
+        assert len(attendees) == 2
+
+        # Check first attendee
+        helpdesk = next((a for a in attendees if "helpdesk" in a.get("email", "")), None)
+        assert helpdesk is not None
+        assert helpdesk.get("email") == "helpdesk@example.com"
+        assert helpdesk.get("name") == "ACME Corp IT Help Desk"
+        assert helpdesk.get("role") == "REQ-PARTICIPANT"
+        assert helpdesk.get("rsvp") == "TRUE"
+
+    def test_organizer_extraction(self, scanner, ics_data):
+        """Test that organizer is correctly extracted."""
+        event = self.run_scan(scanner, ics_data)
+
+        vevent = None
+        for comp in event["calendars"][0]["components"]:
+            if comp.get("type") == "VEVENT":
+                vevent = comp
+                break
+
+        organizers = vevent.get("organizers", [])
+        assert len(organizers) == 1
+        assert organizers[0].get("name") == "ACME Corp Share-File"
+
+    def test_url_extraction_from_description(self, scanner, ics_data):
+        """Test that URLs are extracted from DESCRIPTION field - critical for phishing detection."""
+        event = self.run_scan(scanner, ics_data)
+
+        vevent = None
+        for comp in event["calendars"][0]["components"]:
+            if comp.get("type") == "VEVENT":
+                vevent = comp
+                break
+
+        urls = vevent.get("urls", [])
+        
+        # Should find 3 URLs embedded in the description
+        assert len(urls) == 3
+        
+        # Check for the malicious phishing URL (sanitized test version)
+        phishing_url = next((u for u in urls if "malicious-phishing-site" in u), None)
+        assert phishing_url is not None
+        assert "lambda-url.us-east-1.on.aws" in phishing_url
+        
+        # Check for legitimate URLs also extracted
+        facebook_url = next((u for u in urls if "facebook.com" in u), None)
+        assert facebook_url is not None
+        
+        linkedin_url = next((u for u in urls if "linkedin.com" in u), None)
+        assert linkedin_url is not None
+
+    def test_url_total_count(self, scanner, ics_data):
+        """Test that total URL count is tracked."""
+        event = self.run_scan(scanner, ics_data)
+
+        totals = event.get("total", {})
+        assert totals.get("urls") == 3
+
+    def test_description_contains_phishing_indicators(self, scanner, ics_data):
+        """Test that description text is available for analysis."""
+        event = self.run_scan(scanner, ics_data)
+
+        vevent = None
+        for comp in event["calendars"][0]["components"]:
+            if comp.get("type") == "VEVENT":
+                vevent = comp
+                break
+
+        description = vevent.get("description", "")
+        
+        # Check for phishing indicators in the description
+        assert "Is this phishing?" in description
+        assert "Work_Order_Authorization_Form" in description
+        assert "Job expires on" in description
+        assert "attacker@malicious-domain.org" in description
+
+    def test_datetime_extraction(self, scanner, ics_data):
+        """Test that date/time fields are correctly extracted."""
+        event = self.run_scan(scanner, ics_data)
+
+        vevent = None
+        for comp in event["calendars"][0]["components"]:
+            if comp.get("type") == "VEVENT":
+                vevent = comp
+                break
+
+        # Check that datetime fields are present and formatted
+        assert vevent.get("dtstart") is not None
+        assert vevent.get("dtend") is not None
+        assert "2026-01-14" in vevent.get("dtstart", "")
+
+    def test_no_parse_errors(self, scanner, ics_data):
+        """Test that the ICS file parses without errors."""
+        event = self.run_scan(scanner, ics_data)
+
+        assert "parse_error" not in event
+        assert "ics_parse_error" not in event.get("flags", [])
+
+    def test_timezone_component(self, scanner, ics_data):
+        """Test that timezone components are extracted."""
+        event = self.run_scan(scanner, ics_data)
+
+        vtimezone = None
+        for comp in event["calendars"][0]["components"]:
+            if comp.get("type") == "VTIMEZONE":
+                vtimezone = comp
+                break
+
+        assert vtimezone is not None
+        assert vtimezone.get("tzid") == "Greenwich Standard Time"


### PR DESCRIPTION
# Description

Enhanced ScanIcs to extract URLs embedded in text fields (DESCRIPTION, SUMMARY, LOCATION) - a critical capability for detecting phishing attacks delivered via calendar invitations.

Previously, the scanner only extracted URLs from the dedicated iCalendar URL property. However, phishing campaigns commonly embed malicious URLs directly in the event description using patterns like Open<https://malicious-site.com>. 

This change adds:

- A regex pattern (URL_PATTERN) to match HTTP/HTTPS/FTP URLs, including those wrapped in angle brackets
- A new _extract_urls_from_text() method that scans text content for embedded URLs
- Integration with _extract_component_convenience_fields() to automatically extract URLs from DESCRIPTION, SUMMARY, and LOCATION fields
- A new DEFAULT_MAX_URLS_PER_COMPONENT limit (100) to prevent resource exhaustion
- Updated docstring to document the new URL extraction capability
- Additionally, added comprehensive test coverage:
- New test fixture: test_phishing.ics - an anonymized ICS file modeled after a real phishing calendar invite
- New test file: test_scan_ics.py with 11 tests covering metadata extraction, component parsing, attendee/organizer extraction, URL extraction from descriptions, and datetime handling

# Describe testing procedures

Added net new tests

Tests include:

- test_calendar_metadata - Verifies PRODID, VERSION, METHOD extraction
- test_component_counts - Verifies event, timezone, attendee, organizer counts
- test_vevent_metadata - Verifies SUMMARY, UID, LOCATION, STATUS fields
- test_attendee_extraction - Verifies email, name, role, RSVP parsing
- test_organizer_extraction - Verifies organizer CN and email
- test_url_extraction_from_description - Critical: Verifies embedded phishing URLs are extracted
- test_url_total_count - Verifies total URL counter
- test_description_contains_phishing_indicators - Verifies phishing text patterns are preserved
- test_datetime_extraction - Verifies DTSTART/DTEND parsing
- test_no_parse_errors - Verifies clean parsing
- test_timezone_component - Verifies VTIMEZONE extraction

Sample output

```json
{
  "elapsed": 0.002724,
  "flags": [],
  "total": {
    "components": 5,
    "events": 1,
    "todos": 0,
    "journals": 0,
    "timezones": 1,
    "alarms": 0,
    "attachments": 0,
    "extracted_files": 0,
    "attendees": 2,
    "organizers": 1,
    "urls": 3
  },
  "calendars": [
    {
      "prodid": "Microsoft Exchange Server 2010",
      "version": "2.0",
      "method": "REQUEST",
      "components": [
        {
          "type": "VEVENT",
          "attendees": [
            {
              "email": "helpdesk@example.com",
              "name": "ACME Corp IT Help Desk",
              "display_name": "ACME Corp IT Help Desk <helpdesk@example.com>",
              "role": "REQ-PARTICIPANT",
              "partstat": "NEEDS-ACTION",
              "rsvp": "TRUE"
            }
          ],
          "organizers": [
            {
              "email": "AcmeCorp",
              "name": "ACME Corp Share-File",
              "display_name": "ACME Corp Share-File <AcmeCorp>"
            }
          ],
          "attachments": [],
          "urls": [
            "http://www.linkedin.com/company/example",
            "https://malicious-phishing-site.lambda-url.us-east-1.on.aws/?e=dGVzdEBleGFtcGxlLmNvbQ==",
            "https://www.facebook.com/example"
          ],
          "summary": "Fw: Reminder - 2026 Annual Work Report ",
          "description": "Good morning,\n\nIs this phishing?...\nOpen<https://malicious-phishing-site.lambda-url.us-east-1.on.aws/?e=dGVzdEBleGFtcGxlLmNvbQ==>\n...",
          "uid": "test-uid-12345-phishing-ics",
          "dtstart": "2026-01-14T18:56:53+00:00",
          "dtend": "2026-01-14T18:56:53+00:00",
          "location": "Conference Room",
          "status": "CONFIRMED"
        }
      ]
    }
  ]
}
```

# Checklist

[x] My code follows the style guidelines of this project
[x] I have performed a self-review of and tested my code
[x] I have commented my code, particularly in hard-to-understand areas
[x] I have made corresponding changes to the documentation
[x] My changes generate no new warnings