### PR TITLE
Fix typos and remove dead env var in release workflows

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -218,7 +218,6 @@ jobs:
       - name: Build and Push Final Manifests to ECR & DockerHub
         env:
           SEM_VER: ${{ steps.get_ver.outputs.SEM_VER }}
-          MINOR_VERSION:  ${{ steps.get_ver.outputs.MINOR_VERSION }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_GC_REGISTRY: ${{ steps.login-ecr-gov-cloud.outputs.registry }}
         run: |

--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -152,7 +152,7 @@ jobs:
           docker manifest push $ecr_gc:$MAJOR_VERSION
           docker manifest push $docker_hub:$MINOR_VERSION
           docker manifest push $ecr:$MINOR_VERSION
-          docker manifest push $ecr_gc:$MAJOR_VERSION
+          docker manifest push $ecr_gc:$MINOR_VERSION
 
       - name: Pull, Tag, Push BackEnd
         env:
@@ -204,7 +204,7 @@ jobs:
           docker manifest push $ecr_gc:$MAJOR_VERSION
           docker manifest push $docker_hub:$MINOR_VERSION
           docker manifest push $ecr:$MINOR_VERSION
-          docker manifest push $ecr_gc:$MAJOR_VERSION
+          docker manifest push $ecr_gc:$MINOR_VERSION
 
       - name: Pull, Tag, Push Manager
         env:
@@ -256,7 +256,7 @@ jobs:
           docker manifest push $ecr_gc:$MAJOR_VERSION
           docker manifest push $docker_hub:$MINOR_VERSION
           docker manifest push $ecr:$MINOR_VERSION
-          docker manifest push $ecr_gc:$MAJOR_VERSION
+          docker manifest push $ecr_gc:$MINOR_VERSION
 
       - name: Validate All X-Region Replication
         run: |


### PR DESCRIPTION
In tag-latest.yml, the final `docker manifest push` in each of the three per-image blocks pushed `$ecr_gc:$MAJOR_VERSION` instead of `$ecr_gc:$MINOR_VERSION`. Net effect: GovCloud's `:0` tag is pushed twice and GovCloud's `:0.3` is never pushed.

In release-images.yml, the manifest step declared `MINOR_VERSION` from a `steps.get_ver.outputs.MINOR_VERSION` that is never set and never read by the script body. Drop it.

**Describe the change**
See above.

**Describe testing procedures**
This is a shallow change. We'll see on the next release, which I'll do shortly.

**Sample output**
N/A

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of and tested my code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
